### PR TITLE
[hardware interface] Add gmock unit tests

### DIFF
--- a/zephyr_zenoh_hardware_interface/CMakeLists.txt
+++ b/zephyr_zenoh_hardware_interface/CMakeLists.txt
@@ -36,17 +36,19 @@ install(TARGETS zephyr_zenoh_hardware_interface DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
-  # formatting is handled by clang-format via pre-commit, so skip uncrustify
-  set(ament_cmake_uncrustify_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gmock REQUIRED)
+
+  ament_add_gmock(test_zenoh_zephyr_hardware
+    test/test_zenoh_zephyr_hardware.cpp
+  )
+  target_link_libraries(test_zenoh_zephyr_hardware
+    zephyr_zenoh_hardware_interface
+    hardware_interface::hardware_interface
+    zenohcxx::zenohc
+  )
+  target_include_directories(test_zenoh_zephyr_hardware PRIVATE
+    include
+  )
 endif()
 
 ament_package()

--- a/zephyr_zenoh_hardware_interface/package.xml
+++ b/zephyr_zenoh_hardware_interface/package.xml
@@ -9,8 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
 
   <depend>hardware_interface</depend>
   <depend>rclcpp</depend>

--- a/zephyr_zenoh_hardware_interface/test/test_zenoh_zephyr_hardware.cpp
+++ b/zephyr_zenoh_hardware_interface/test/test_zenoh_zephyr_hardware.cpp
@@ -1,0 +1,94 @@
+// Copyright 2026 kamal2730
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "zephyr_zenoh_hardware_interface/zenoh_zephyr_hardware.hpp"
+
+class TestZenohZephyrHardware : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Build HardwareComponentInterfaceParams with test data
+    hardware_interface::HardwareInfo info;
+    info.name = "test_hw";
+    info.hardware_parameters["zenoh_endpoint"] = "tcp/localhost:7447";
+    info.hardware_parameters["state_topic"] = "joint_states";
+    info.hardware_parameters["command_topic"] = "joint_commands";
+    info.hardware_parameters["zenoh_mode"] = "client";
+
+    hardware_interface::ComponentInfo joint;
+    joint.name = "test_joint";
+    hardware_interface::InterfaceInfo si;
+    si.name = "position";
+    joint.state_interfaces.push_back(si);
+
+    hardware_interface::InterfaceInfo ci;
+    ci.name = "position";
+    joint.command_interfaces.push_back(ci);
+    info.joints.push_back(joint);
+
+    hardware_interface::HardwareComponentInterfaceParams params;
+    params.hardware_info = info;
+
+    hw_ = std::make_unique<zephyr_zenoh::ZenohZephyrHardware>();
+    ASSERT_EQ(hw_->on_init(params), hardware_interface::CallbackReturn::SUCCESS);
+  }
+
+  std::unique_ptr<zephyr_zenoh::ZenohZephyrHardware> hw_;
+};
+
+TEST_F(TestZenohZephyrHardware, missing_parameter_fails)
+{
+  hardware_interface::HardwareInfo info;
+  info.name = "test_hw";
+  // Intentionally NOT setting zenoh_endpoint, state_topic, command_topic
+  hardware_interface::ComponentInfo joint;
+  joint.name = "test_joint";
+  hardware_interface::InterfaceInfo si;
+  si.name = "position";
+  joint.state_interfaces.push_back(si);
+
+  hardware_interface::InterfaceInfo ci;
+  ci.name = "position";
+  joint.command_interfaces.push_back(ci);
+  info.joints.push_back(joint);
+
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = info;
+
+  auto hw = std::make_unique<zephyr_zenoh::ZenohZephyrHardware>();
+  EXPECT_EQ(hw->on_init(params), hardware_interface::CallbackReturn::ERROR);
+}
+
+TEST_F(TestZenohZephyrHardware, state_interfaces_exported)
+{
+  auto si = hw_->export_state_interfaces();
+  EXPECT_EQ(si.size(), 1);
+  EXPECT_EQ(si[0].get_name(), "test_joint/position");
+  EXPECT_EQ(si[0].get_interface_name(), "position");
+}
+
+TEST_F(TestZenohZephyrHardware, command_interfaces_exported)
+{
+  auto ci = hw_->export_command_interfaces();
+  EXPECT_EQ(ci.size(), 1);
+  EXPECT_EQ(ci[0].get_name(), "test_joint/position");
+  EXPECT_EQ(ci[0].get_interface_name(), "position");
+}


### PR DESCRIPTION
## Description

- **Removed `ament_lint_auto` and `ament_lint_common`** — deprecated in favor of pre-commit
- **Set up gmock testing suite** 
- **Added parameter tests** — `test_zenoh_zephyr_hardware.cpp` with 3 test cases covering missing parameters, state interface export, and command interface export.
