### PR TITLE
Fix Docker build: toolchain name, Zephyr pin, mounts, and env

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,17 +22,20 @@ RUN pip3 install --break-system-packages west
 
 # Set up Zephyr workspace
 WORKDIR /zephyr_ws
-RUN west init . && west update && west zephyr-export
+ARG ZEPHYR_VERSION=v3.7.0
+RUN west init -m https://github.com/zephyrproject-rtos/zephyr --mr ${ZEPHYR_VERSION} . \
+    && west update \
+    && west zephyr-export
 
 # Install Zephyr SDK (targeting ESP32 and ARM)
 RUN wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-x86_64.tar.xz \
     && tar xf zephyr-sdk-0.16.8_linux-x86_64.tar.xz \
-    && cd zephyr-sdk-0.16.8 && ./setup.sh -t espressif -t arm-zephyr-eabi -c -h \
+    && cd zephyr-sdk-0.16.8 && ./setup.sh -t xtensa-espressif_esp32_zephyr-elf -t arm-zephyr-eabi -c -h \
     && cd .. && rm zephyr-sdk-0.16.8_linux-x86_64.tar.xz
 
 # Set environment variables
 ENV ZEPHYR_BASE=/zephyr_ws/zephyr
-ENV PATH="/zephyr_ws/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin:${PATH}"
+ENV PATH="/zephyr_ws/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin:/zephyr_ws/zephyr-sdk-0.16.8/xtensa-espressif_esp32_zephyr-elf/bin:${PATH}"
 ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
 
 # Copy python requirements from zephyr and install
@@ -42,4 +45,5 @@ RUN pip3 install --break-system-packages -r /zephyr_ws/zephyr/scripts/requiremen
 RUN mkdir -p /ros2_ws/src
 WORKDIR /ros2_ws
 
-CMD ["/bin/bash", "-c", "source /opt/ros/jazzy/setup.bash && exec /bin/bash"]
+RUN echo "source /opt/ros/jazzy/setup.bash" >> /root/.bashrc
+CMD ["/bin/bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@ This folder contains the Docker and Compose configurations to ensure a reproduci
 
 ## Quick Start
 1. Start the environment: `docker compose up -d`
-2. Access the Docker environment: `docker compose exec zenoh-zephyr-dev bash`
+2. Access the Docker environment: `docker compose exec dev-env bash`
 
 ## Mount Points
 - `zephyr_zenoh_transport/` is shared across both containers to ensure serialization logic is always in sync.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       # ros2 workspace mapping
       - ../zephyr_zenoh_transport:/ros2_ws/src/zephyr_zenoh_transport
-      - ../ros_hardware_interface:/ros2_ws/src/ros_hardware_interface
+      - ../zephyr_zenoh_hardware_interface:/ros2_ws/src/zephyr_zenoh_hardware_interface
 
       #zephyr workspace mapping
       - ../zephyr_zenoh_transport:/zephyr_ws/zephyr_zenoh_transport


### PR DESCRIPTION
- Pin Zephyr version to v3.7.0
- Correct Espressif toolchain name to xtensa-espressif_esp32_zephyr-elf
- Add Espressif toolchain to PATH
- Fix README docker compose exec service name
- Ensure ROS 2 environment is sourced in all interactive shells
- Fix volume mount for zephyr_zenoh_hardware_interface

Fixes https://github.com/ros-controls/zephyr-zenoh-integration/issues/3