### PR TITLE
[hardware interface] Open Zenoh session in lifecycle and add embedded router test

### DIFF
--- a/zephyr_zenoh_hardware_interface/include/zephyr_zenoh_hardware_interface/zenoh_zephyr_hardware.hpp
+++ b/zephyr_zenoh_hardware_interface/include/zephyr_zenoh_hardware_interface/zenoh_zephyr_hardware.hpp
@@ -15,6 +15,7 @@
 #ifndef ZEPHYR_ZENOH_HARDWARE_INTERFACE__ZENOH_ZEPHYR_HARDWARE_HPP_
 #define ZEPHYR_ZENOH_HARDWARE_INTERFACE__ZENOH_ZEPHYR_HARDWARE_HPP_
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -55,6 +56,7 @@ public:
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
 private:
+  std::unique_ptr<zenoh::Session> session_;
   std::vector<double> hw_commands_;
   std::vector<double> hw_states_;
   std::vector<double> hw_state_buffer_;

--- a/zephyr_zenoh_hardware_interface/src/zenoh_zephyr_hardware.cpp
+++ b/zephyr_zenoh_hardware_interface/src/zenoh_zephyr_hardware.cpp
@@ -83,13 +83,26 @@ std::vector<hardware_interface::CommandInterface> ZenohZephyrHardware::export_co
 
 CallbackReturn ZenohZephyrHardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  for (size_t i = 0; i < hw_states_.size(); i++)
+  try
   {
-    if (std::isnan(hw_states_[i]))
+    auto config = zenoh::Config::create_default();
+    config.insert_json5("connect/endpoints", "[\"" + zenoh_endpoint_ + "\"]");
+    config.insert_json5("mode", "\"" + zenoh_mode_ + "\"");
+    session_ = std::make_unique<zenoh::Session>(std::move(config));
+
+    for (size_t i = 0; i < hw_states_.size(); i++)
     {
-      hw_states_[i] = 0;
-      hw_commands_[i] = 0;
+      if (std::isnan(hw_states_[i]))
+      {
+        hw_states_[i] = 0;
+        hw_commands_[i] = 0;
+      }
     }
+  }
+  catch (const std::exception & e)
+  {
+    RCLCPP_FATAL(rclcpp::get_logger("ZenohZephyrHardware"), "Zenoh failed: %s", e.what());
+    return CallbackReturn::ERROR;
   }
   RCLCPP_INFO(rclcpp::get_logger("ZenohZephyrHardware"), "Hardware activated!");
   return CallbackReturn::SUCCESS;
@@ -98,6 +111,7 @@ CallbackReturn ZenohZephyrHardware::on_activate(const rclcpp_lifecycle::State & 
 CallbackReturn ZenohZephyrHardware::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  session_.reset();
   RCLCPP_INFO(rclcpp::get_logger("ZenohZephyrHardware"), "Hardware deactivated.");
   return CallbackReturn::SUCCESS;
 }

--- a/zephyr_zenoh_hardware_interface/test/test_zenoh_zephyr_hardware.cpp
+++ b/zephyr_zenoh_hardware_interface/test/test_zenoh_zephyr_hardware.cpp
@@ -17,18 +17,33 @@
 #include <string>
 #include <vector>
 
+#include <rclcpp_lifecycle/state.hpp>
+#include <zenoh.hxx>
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "zephyr_zenoh_hardware_interface/zenoh_zephyr_hardware.hpp"
+
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 class TestZenohZephyrHardware : public ::testing::Test
 {
 protected:
+  static void SetUpTestSuite()
+  {
+    auto cfg = zenoh::Config::create_default();
+    cfg.insert_json5("listen/endpoints", R"(["tcp/127.0.0.1:21555"])");
+    cfg.insert_json5("mode", "\"peer\"");
+    test_router_ = std::make_unique<zenoh::Session>(std::move(cfg));
+    ASSERT_NE(test_router_, nullptr);
+  }
+
+  static void TearDownTestSuite() { test_router_.reset(); }
+
   void SetUp() override
   {
     // Build HardwareComponentInterfaceParams with test data
     hardware_interface::HardwareInfo info;
     info.name = "test_hw";
-    info.hardware_parameters["zenoh_endpoint"] = "tcp/localhost:7447";
+    info.hardware_parameters["zenoh_endpoint"] = "tcp/127.0.0.1:21555";
     info.hardware_parameters["state_topic"] = "joint_states";
     info.hardware_parameters["command_topic"] = "joint_commands";
     info.hardware_parameters["zenoh_mode"] = "client";
@@ -48,11 +63,14 @@ protected:
     params.hardware_info = info;
 
     hw_ = std::make_unique<zephyr_zenoh::ZenohZephyrHardware>();
-    ASSERT_EQ(hw_->on_init(params), hardware_interface::CallbackReturn::SUCCESS);
+    ASSERT_EQ(hw_->on_init(params), CallbackReturn::SUCCESS);
   }
 
+  static std::unique_ptr<zenoh::Session> test_router_;
   std::unique_ptr<zephyr_zenoh::ZenohZephyrHardware> hw_;
 };
+
+std::unique_ptr<zenoh::Session> TestZenohZephyrHardware::test_router_ = nullptr;
 
 TEST_F(TestZenohZephyrHardware, missing_parameter_fails)
 {
@@ -74,7 +92,7 @@ TEST_F(TestZenohZephyrHardware, missing_parameter_fails)
   params.hardware_info = info;
 
   auto hw = std::make_unique<zephyr_zenoh::ZenohZephyrHardware>();
-  EXPECT_EQ(hw->on_init(params), hardware_interface::CallbackReturn::ERROR);
+  EXPECT_EQ(hw->on_init(params), CallbackReturn::ERROR);
 }
 
 TEST_F(TestZenohZephyrHardware, state_interfaces_exported)
@@ -91,4 +109,41 @@ TEST_F(TestZenohZephyrHardware, command_interfaces_exported)
   EXPECT_EQ(ci.size(), 1);
   EXPECT_EQ(ci[0].get_name(), "test_joint/position");
   EXPECT_EQ(ci[0].get_interface_name(), "position");
+}
+
+TEST_F(TestZenohZephyrHardware, activate_succeeds_with_router)
+{
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  EXPECT_EQ(hw_->on_activate(state), CallbackReturn::SUCCESS);
+  EXPECT_EQ(hw_->on_deactivate(state), CallbackReturn::SUCCESS);
+}
+
+TEST_F(TestZenohZephyrHardware, activate_fails_with_bad_endpoint)
+{
+  // Use a port unlikely to be running a Zenoh router
+  hardware_interface::HardwareInfo info;
+  info.name = "test_hw";
+  info.hardware_parameters["zenoh_endpoint"] = "tcp/127.0.0.1:1";
+  info.hardware_parameters["state_topic"] = "joint_states";
+  info.hardware_parameters["command_topic"] = "joint_commands";
+  info.hardware_parameters["zenoh_mode"] = "client";
+
+  hardware_interface::ComponentInfo joint;
+  joint.name = "test_joint";
+  hardware_interface::InterfaceInfo si;
+  si.name = "position";
+  joint.state_interfaces.push_back(si);
+  hardware_interface::InterfaceInfo ci;
+  ci.name = "position";
+  joint.command_interfaces.push_back(ci);
+  info.joints.push_back(joint);
+
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = info;
+
+  auto hw = std::make_unique<zephyr_zenoh::ZenohZephyrHardware>();
+  ASSERT_EQ(hw->on_init(params), CallbackReturn::SUCCESS);
+
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  EXPECT_EQ(hw->on_activate(state), CallbackReturn::ERROR);
 }


### PR DESCRIPTION
## Summary

- Wire real Zenoh session in on_activate / on_deactivate lifecycle
- Add in-code Zenoh peer router to test suite
- Add connectivity test: activate resolves when router is reachable