### PR TITLE
ci: build & publish zephyr dev image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,59 @@
+name: Docker Image Build & Publish
+
+on:
+  workflow_dispatch:
+  pull_request: &event
+    branches:
+      - master
+    paths:
+      - 'docker/**'
+      - 'zenbedded_transport/west.yml'
+      - '.github/workflows/docker-build.yml'
+  push: *event
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
+env:
+  IMAGE: ghcr.io/ros-controls/zephyr-zenoh-integration/zephyr-zenoh-dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name != 'pull_request' }}
+            type=sha,format=short,enable=${{ github.event_name != 'pull_request' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,13 @@ RUN apt-get update && apt-get install -y \
 # Install West
 RUN pip3 install --break-system-packages west
 
-# Set up Zephyr workspace
+# Set up Zephyr workspace with zenoh-pico preloaded
 WORKDIR /zephyr_ws
-RUN west init -m https://github.com/zephyrproject-rtos/zephyr --mr v3.7.0 . && west update && west zephyr-export
+COPY docker/image-west.yml        manifest-repo/west.yml
+COPY zenbedded_transport/west.yml manifest-repo/zenbedded_transport.yml
+RUN cd manifest-repo && git init -q && git add . \
+    && git -c user.email=ci@local -c user.name=ci commit -qm "image manifest"
+RUN west init -l manifest-repo && west update && west zephyr-export
 
 # Copy python requirements from zephyr and install
 RUN pip3 install --ignore-installed --break-system-packages -r /zephyr_ws/zephyr/scripts/requirements.txt

--- a/docker/image-west.yml
+++ b/docker/image-west.yml
@@ -1,0 +1,13 @@
+manifest:
+  remotes:
+    - name: zephyrproject-rtos
+      url-base: https://github.com/zephyrproject-rtos
+
+  projects:
+    - name: zephyr
+      remote: zephyrproject-rtos
+      revision: v3.7.0
+      import: true
+
+  self:
+    import: zenbedded_transport.yml


### PR DESCRIPTION
- Adds a workflow that builds the Docker dev image and pushes it to GHCR.
- Pushes `:latest` and `:<sha>` on master; build-only on PRs.
- Preloads zenoh-pico 1.9.0 into the image so CI doesn't fetch it each run.