### PR TITLE
ci: build zephyr apps with twister

### DIFF
--- a/.github/workflows/zephyr-twister.yml
+++ b/.github/workflows/zephyr-twister.yml
@@ -6,15 +6,9 @@ on:
     branches:
       - master
     paths:
-      - '**.c'
-      - '**.cpp'
-      - '**.h'
-      - '**.hpp'
-      - '**/prj.conf'
-      - '**/boards/*.conf'
-      - '**/*.overlay'
-      - '**/CMakeLists.txt'
-      - '**/sample.yaml'
+      - 'demos/**'
+      - 'zenbedded_rcl/**'
+      - 'zenbedded_transport/**'
       - '.github/workflows/zephyr-twister.yml'
   push: *event
 

--- a/.github/workflows/zephyr-twister.yml
+++ b/.github/workflows/zephyr-twister.yml
@@ -1,0 +1,57 @@
+name: Zephyr Twister
+
+on:
+  workflow_dispatch:
+  pull_request: &event
+    branches:
+      - master
+    paths:
+      - '**.c'
+      - '**.cpp'
+      - '**.h'
+      - '**.hpp'
+      - '**/prj.conf'
+      - '**/boards/*.conf'
+      - '**/*.overlay'
+      - '**/CMakeLists.txt'
+      - '**/sample.yaml'
+      - '.github/workflows/zephyr-twister.yml'
+  push: *event
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
+jobs:
+  twister:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/ros-controls/zephyr-zenoh-integration/zephyr-zenoh-dev:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run twister (build only)
+        shell: bash
+        run: |
+          export ZEPHYR_BASE=/zephyr_ws/zephyr
+          "$ZEPHYR_BASE/scripts/twister" \
+            --testsuite-root demos/inverted_pendulum \
+            --testsuite-root zenbedded_rcl \
+            --platform native_sim \
+            --platform esp32s3_devkitc/esp32s3/procpu \
+            --inline-logs \
+            --outdir twister-out
+
+      - name: Upload twister output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: twister-out
+          path: twister-out
+          if-no-files-found: ignore

--- a/demos/inverted_pendulum/sample.yaml
+++ b/demos/inverted_pendulum/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: Inverted Pendulum Zenoh Demo
+common:
+  build_only: true
+  tags: zenoh
+tests:
+  sample.zenbedded.inverted_pendulum:
+    platform_allow:
+      - native_sim
+      - esp32s3_devkitc/esp32s3/procpu

--- a/zenbedded_rcl/sample.yaml
+++ b/zenbedded_rcl/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: Zenbedded RCL
+common:
+  build_only: true
+  tags: zenoh
+tests:
+  sample.zenbedded.rcl:
+    platform_allow:
+      - native_sim
+      - esp32s3_devkitc/esp32s3/procpu


### PR DESCRIPTION
- Adds a twister workflow that builds the Zephyr apps in the published dev image.
- Builds the demo and zenbedded_rcl for native_sim and esp32s3, build-only for now.
- Adds a sample.yaml to each app so twister picks them up.

Depends on the dev image being published, so CI here goes green only after #15 , #17 merged.