### PR TITLE
ci: make zephyr sdk discoverable in the dev image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16
 
 # Set environment variables
 ENV ZEPHYR_BASE=/zephyr_ws/zephyr
+ENV ZEPHYR_SDK_INSTALL_DIR=/zephyr_ws/zephyr-sdk-0.16.8
 ENV PATH="/zephyr_ws/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin:/zephyr_ws/zephyr-sdk-0.16.8/xtensa-espressif_esp32_zephyr-elf/bin:/zephyr_ws/zephyr-sdk-0.16.8/xtensa-espressif_esp32s3_zephyr-elf/bin:${PATH}"
 ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,6 @@ RUN wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16
 # Set environment variables
 ENV ZEPHYR_BASE=/zephyr_ws/zephyr
 ENV ZEPHYR_SDK_INSTALL_DIR=/zephyr_ws/zephyr-sdk-0.16.8
-ENV PATH="/zephyr_ws/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin:/zephyr_ws/zephyr-sdk-0.16.8/xtensa-espressif_esp32_zephyr-elf/bin:/zephyr_ws/zephyr-sdk-0.16.8/xtensa-espressif_esp32s3_zephyr-elf/bin:${PATH}"
 ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
 
 # Set up ROS 2 workspace structure


### PR DESCRIPTION
- Sets ZEPHYR_SDK_INSTALL_DIR so Zephyr finds the SDK by path.
- The setup.sh -c cmake registry lives under HOME, which GitHub Actions overrides, so container builds couldn't find the SDK.
- Drops the manual SDK PATH entries, now redundant.