### PR TITLE
[hardware interface] Rename zephyr_zenoh to zenbedded

### DIFF
--- a/zenbedded_hardware_interface/CMakeLists.txt
+++ b/zenbedded_hardware_interface/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(zephyr_zenoh_hardware_interface)
+project(zenbedded_hardware_interface)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -14,16 +14,16 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(zenoh_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-add_library(zephyr_zenoh_hardware_interface SHARED
-  src/zenoh_zephyr_hardware.cpp
+add_library(zenbedded_hardware_interface SHARED
+  src/zenbedded_hardware.cpp
   src/interface_schema.cpp
 )
 
-target_include_directories(zephyr_zenoh_hardware_interface PRIVATE
+target_include_directories(zenbedded_hardware_interface PRIVATE
   include
 )
 
-target_link_libraries(zephyr_zenoh_hardware_interface
+target_link_libraries(zenbedded_hardware_interface
   PRIVATE
     hardware_interface::hardware_interface
     pluginlib::pluginlib
@@ -33,30 +33,30 @@ target_link_libraries(zephyr_zenoh_hardware_interface
     yaml-cpp::yaml-cpp
 )
 
-pluginlib_export_plugin_description_file(hardware_interface zenoh_zephyr_hardware_interface.xml)
+pluginlib_export_plugin_description_file(hardware_interface zenbedded_hardware_interface.xml)
 
-install(TARGETS zephyr_zenoh_hardware_interface DESTINATION lib)
+install(TARGETS zenbedded_hardware_interface DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
 
-  ament_add_gmock(test_zenoh_zephyr_hardware
-    test/test_zenoh_zephyr_hardware.cpp
+  ament_add_gmock(test_zenbedded_hardware
+    test/test_zenbedded_hardware.cpp
   )
-  target_link_libraries(test_zenoh_zephyr_hardware
-    zephyr_zenoh_hardware_interface
+  target_link_libraries(test_zenbedded_hardware
+    zenbedded_hardware_interface
     hardware_interface::hardware_interface
     zenohcxx::zenohc
   )
-  target_include_directories(test_zenoh_zephyr_hardware PRIVATE
+  target_include_directories(test_zenbedded_hardware PRIVATE
     include
   )
   ament_add_gmock(test_interface_schema
     test/test_interface_schema.cpp
   )
   target_link_libraries(test_interface_schema
-    zephyr_zenoh_hardware_interface
+    zenbedded_hardware_interface
     yaml-cpp::yaml-cpp
   )
   target_include_directories(test_interface_schema PRIVATE

--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/interface_schema.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/interface_schema.hpp
@@ -11,14 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef ZEPHYR_ZENOH_HARDWARE_INTERFACE__INTERFACE_SCHEMA_HPP_
-#define ZEPHYR_ZENOH_HARDWARE_INTERFACE__INTERFACE_SCHEMA_HPP_
+#ifndef ZENBEDDED_HARDWARE_INTERFACE__INTERFACE_SCHEMA_HPP_
+#define ZENBEDDED_HARDWARE_INTERFACE__INTERFACE_SCHEMA_HPP_
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
-namespace zephyr_zenoh
+namespace zenbedded
 {
 
 enum class FieldType : uint8_t
@@ -83,6 +83,6 @@ private:
   std::vector<FlatField> command_flat_fields_;
 };
 
-}  // namespace zephyr_zenoh
+}  // namespace zenbedded
 
-#endif  // ZEPHYR_ZENOH_HARDWARE_INTERFACE__INTERFACE_SCHEMA_HPP_
+#endif  // ZENBEDDED_HARDWARE_INTERFACE__INTERFACE_SCHEMA_HPP_

--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ZEPHYR_ZENOH_HARDWARE_INTERFACE__ZENOH_ZEPHYR_HARDWARE_HPP_
-#define ZEPHYR_ZENOH_HARDWARE_INTERFACE__ZENOH_ZEPHYR_HARDWARE_HPP_
+#ifndef ZENBEDDED_HARDWARE_INTERFACE__ZENBEDDED_HARDWARE_HPP_
+#define ZENBEDDED_HARDWARE_INTERFACE__ZENBEDDED_HARDWARE_HPP_
 
 #include <memory>
 #include <mutex>
@@ -29,14 +29,14 @@
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 
-namespace zephyr_zenoh
+namespace zenbedded
 {
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
-class ZenohZephyrHardware : public hardware_interface::SystemInterface
+class ZenbeddedHardware : public hardware_interface::SystemInterface
 {
 public:
-  RCLCPP_SHARED_PTR_DEFINITIONS(ZenohZephyrHardware)
+  RCLCPP_SHARED_PTR_DEFINITIONS(ZenbeddedHardware)
 
   CallbackReturn on_init(
     const hardware_interface::HardwareComponentInterfaceParams & params) override;
@@ -67,6 +67,6 @@ private:
   std::string command_topic_;
 };
 
-}  // namespace zephyr_zenoh
+}  // namespace zenbedded
 
-#endif  // ZEPHYR_ZENOH_HARDWARE_INTERFACE__ZENOH_ZEPHYR_HARDWARE_HPP_
+#endif  // ZENBEDDED_HARDWARE_INTERFACE__ZENBEDDED_HARDWARE_HPP_

--- a/zenbedded_hardware_interface/package.xml
+++ b/zenbedded_hardware_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>zephyr_zenoh_hardware_interface</name>
+  <name>zenbedded_hardware_interface</name>
   <version>0.0.1</version>
   <description>Zenoh-based hardware interface for Zephyr RTOS and ros2_control</description>
   <maintainer email="itzkamalkant@gmail.com">kamal2730</maintainer>
@@ -20,6 +20,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
-    <hardware_interface_plugin>zenoh_zephyr_hardware_interface.xml</hardware_interface_plugin>
+    <hardware_interface_plugin>zenbedded_hardware_interface.xml</hardware_interface_plugin>
   </export>
 </package>

--- a/zenbedded_hardware_interface/src/interface_schema.cpp
+++ b/zenbedded_hardware_interface/src/interface_schema.cpp
@@ -11,11 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "zephyr_zenoh_hardware_interface/interface_schema.hpp"
+#include "zenbedded_hardware_interface/interface_schema.hpp"
 
 #include <yaml-cpp/yaml.h>
 
-namespace zephyr_zenoh
+namespace zenbedded
 {
 
 FieldType parse_field_type(const std::string & type_str, std::string & error)
@@ -129,4 +129,4 @@ InterfaceSchema InterfaceSchema::from_yaml(const std::string & yaml_text)
   return schema;
 }
 
-}  // namespace zephyr_zenoh
+}  // namespace zenbedded

--- a/zenbedded_hardware_interface/src/zenbedded_hardware.cpp
+++ b/zenbedded_hardware_interface/src/zenbedded_hardware.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "zephyr_zenoh_hardware_interface/zenoh_zephyr_hardware.hpp"
+#include "zenbedded_hardware_interface/zenbedded_hardware.hpp"
 
 #include <chrono>
 #include <cmath>
@@ -23,10 +23,10 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-namespace zephyr_zenoh
+namespace zenbedded
 {
 
-CallbackReturn ZenohZephyrHardware::on_init(
+CallbackReturn ZenbeddedHardware::on_init(
   const hardware_interface::HardwareComponentInterfaceParams & params)
 {
   if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS)
@@ -45,7 +45,7 @@ CallbackReturn ZenohZephyrHardware::on_init(
   }
   catch (const std::out_of_range & e)
   {
-    RCLCPP_FATAL(rclcpp::get_logger("ZenohZephyrHardware"), "Missing required URDF parameter");
+    RCLCPP_FATAL(rclcpp::get_logger("ZenbeddedHardware"), "Missing required URDF parameter");
     return CallbackReturn::ERROR;
   }
 
@@ -53,11 +53,11 @@ CallbackReturn ZenohZephyrHardware::on_init(
   hw_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_state_buffer_.resize(info_.joints.size(), 0.0);
 
-  RCLCPP_INFO(rclcpp::get_logger("ZenohZephyrHardware"), "Hardware Interface Initialized!");
+  RCLCPP_INFO(rclcpp::get_logger("ZenbeddedHardware"), "Hardware Interface Initialized!");
   return CallbackReturn::SUCCESS;
 }
 
-std::vector<hardware_interface::StateInterface> ZenohZephyrHardware::export_state_interfaces()
+std::vector<hardware_interface::StateInterface> ZenbeddedHardware::export_state_interfaces()
 {
   std::vector<hardware_interface::StateInterface> state_interfaces;
   for (size_t i = 0; i < info_.joints.size(); i++)
@@ -69,7 +69,7 @@ std::vector<hardware_interface::StateInterface> ZenohZephyrHardware::export_stat
   return state_interfaces;
 }
 
-std::vector<hardware_interface::CommandInterface> ZenohZephyrHardware::export_command_interfaces()
+std::vector<hardware_interface::CommandInterface> ZenbeddedHardware::export_command_interfaces()
 {
   std::vector<hardware_interface::CommandInterface> command_interfaces;
   for (size_t i = 0; i < info_.joints.size(); i++)
@@ -81,7 +81,7 @@ std::vector<hardware_interface::CommandInterface> ZenohZephyrHardware::export_co
   return command_interfaces;
 }
 
-CallbackReturn ZenohZephyrHardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+CallbackReturn ZenbeddedHardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   try
   {
@@ -101,22 +101,21 @@ CallbackReturn ZenohZephyrHardware::on_activate(const rclcpp_lifecycle::State & 
   }
   catch (const std::exception & e)
   {
-    RCLCPP_FATAL(rclcpp::get_logger("ZenohZephyrHardware"), "Zenoh failed: %s", e.what());
+    RCLCPP_FATAL(rclcpp::get_logger("ZenbeddedHardware"), "Zenoh failed: %s", e.what());
     return CallbackReturn::ERROR;
   }
-  RCLCPP_INFO(rclcpp::get_logger("ZenohZephyrHardware"), "Hardware activated!");
+  RCLCPP_INFO(rclcpp::get_logger("ZenbeddedHardware"), "Hardware activated!");
   return CallbackReturn::SUCCESS;
 }
 
-CallbackReturn ZenohZephyrHardware::on_deactivate(
-  const rclcpp_lifecycle::State & /*previous_state*/)
+CallbackReturn ZenbeddedHardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   session_.reset();
-  RCLCPP_INFO(rclcpp::get_logger("ZenohZephyrHardware"), "Hardware deactivated.");
+  RCLCPP_INFO(rclcpp::get_logger("ZenbeddedHardware"), "Hardware deactivated.");
   return CallbackReturn::SUCCESS;
 }
 
-hardware_interface::return_type ZenohZephyrHardware::read(
+hardware_interface::return_type ZenbeddedHardware::read(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
   std::lock_guard<std::mutex> lock(data_mutex_);
@@ -127,7 +126,7 @@ hardware_interface::return_type ZenohZephyrHardware::read(
   return hardware_interface::return_type::OK;
 }
 
-hardware_interface::return_type ZenohZephyrHardware::write(
+hardware_interface::return_type ZenbeddedHardware::write(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
   std::lock_guard<std::mutex> lock(data_mutex_);
@@ -138,8 +137,8 @@ hardware_interface::return_type ZenohZephyrHardware::write(
   return hardware_interface::return_type::OK;
 }
 
-}  // namespace zephyr_zenoh
+}  // namespace zenbedded
 
 #include "pluginlib/class_list_macros.hpp"
 
-PLUGINLIB_EXPORT_CLASS(zephyr_zenoh::ZenohZephyrHardware, hardware_interface::SystemInterface)
+PLUGINLIB_EXPORT_CLASS(zenbedded::ZenbeddedHardware, hardware_interface::SystemInterface)

--- a/zenbedded_hardware_interface/test/test_interface_schema.cpp
+++ b/zenbedded_hardware_interface/test/test_interface_schema.cpp
@@ -14,7 +14,7 @@
 #include <gmock/gmock.h>
 #include <string>
 
-#include "zephyr_zenoh_hardware_interface/interface_schema.hpp"
+#include "zenbedded_hardware_interface/interface_schema.hpp"
 
 class TestInterfaceSchema : public ::testing::Test
 {
@@ -49,7 +49,7 @@ command_interfaces:
 
 TEST_F(TestInterfaceSchema, simple_schema)
 {
-  auto schema = zephyr_zenoh::InterfaceSchema::from_yaml(simple_yaml);
+  auto schema = zenbedded::InterfaceSchema::from_yaml(simple_yaml);
   EXPECT_TRUE(schema.valid());
   EXPECT_TRUE(schema.error().empty());
   EXPECT_EQ(schema.total_state_interfaces(), 2);
@@ -58,7 +58,7 @@ TEST_F(TestInterfaceSchema, simple_schema)
 
 TEST_F(TestInterfaceSchema, multi_field_components)
 {
-  auto schema = zephyr_zenoh::InterfaceSchema::from_yaml(multi_field_yaml);
+  auto schema = zenbedded::InterfaceSchema::from_yaml(multi_field_yaml);
   EXPECT_TRUE(schema.valid());
   EXPECT_TRUE(schema.error().empty());
   EXPECT_EQ(schema.total_state_interfaces(), 5);
@@ -68,7 +68,7 @@ TEST_F(TestInterfaceSchema, multi_field_components)
 TEST_F(TestInterfaceSchema, missing_state_interfaces_fails)
 {
   auto schema =
-    zephyr_zenoh::InterfaceSchema::from_yaml("command_interfaces:\n  joint:\n    pos: float32\n");
+    zenbedded::InterfaceSchema::from_yaml("command_interfaces:\n  joint:\n    pos: float32\n");
   EXPECT_FALSE(schema.valid());
   EXPECT_FALSE(schema.error().empty());
   EXPECT_THAT(schema.error(), ::testing::HasSubstr("state_interfaces"));
@@ -77,7 +77,7 @@ TEST_F(TestInterfaceSchema, missing_state_interfaces_fails)
 TEST_F(TestInterfaceSchema, missing_command_interfaces_fails)
 {
   auto schema =
-    zephyr_zenoh::InterfaceSchema::from_yaml("state_interfaces:\n  joint:\n    pos: float32\n");
+    zenbedded::InterfaceSchema::from_yaml("state_interfaces:\n  joint:\n    pos: float32\n");
   EXPECT_FALSE(schema.valid());
   EXPECT_FALSE(schema.error().empty());
   EXPECT_THAT(schema.error(), ::testing::HasSubstr("command_interfaces"));
@@ -85,14 +85,14 @@ TEST_F(TestInterfaceSchema, missing_command_interfaces_fails)
 
 TEST_F(TestInterfaceSchema, empty_yaml_fails)
 {
-  auto schema = zephyr_zenoh::InterfaceSchema::from_yaml("");
+  auto schema = zenbedded::InterfaceSchema::from_yaml("");
   EXPECT_FALSE(schema.valid());
   EXPECT_FALSE(schema.error().empty());
 }
 
 TEST_F(TestInterfaceSchema, invalid_yaml_fails)
 {
-  auto schema = zephyr_zenoh::InterfaceSchema::from_yaml("{invalid: [yaml");
+  auto schema = zenbedded::InterfaceSchema::from_yaml("{invalid: [yaml");
   EXPECT_FALSE(schema.valid());
   EXPECT_FALSE(schema.error().empty());
 }

--- a/zenbedded_hardware_interface/test/test_zenbedded_hardware.cpp
+++ b/zenbedded_hardware_interface/test/test_zenbedded_hardware.cpp
@@ -20,11 +20,11 @@
 #include <rclcpp_lifecycle/state.hpp>
 #include <zenoh.hxx>
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "zephyr_zenoh_hardware_interface/zenoh_zephyr_hardware.hpp"
+#include "zenbedded_hardware_interface/zenbedded_hardware.hpp"
 
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
-class TestZenohZephyrHardware : public ::testing::Test
+class TestZenbeddedHardware : public ::testing::Test
 {
 protected:
   static void SetUpTestSuite()
@@ -62,17 +62,17 @@ protected:
     hardware_interface::HardwareComponentInterfaceParams params;
     params.hardware_info = info;
 
-    hw_ = std::make_unique<zephyr_zenoh::ZenohZephyrHardware>();
+    hw_ = std::make_unique<zenbedded::ZenbeddedHardware>();
     ASSERT_EQ(hw_->on_init(params), CallbackReturn::SUCCESS);
   }
 
   static std::unique_ptr<zenoh::Session> test_router_;
-  std::unique_ptr<zephyr_zenoh::ZenohZephyrHardware> hw_;
+  std::unique_ptr<zenbedded::ZenbeddedHardware> hw_;
 };
 
-std::unique_ptr<zenoh::Session> TestZenohZephyrHardware::test_router_ = nullptr;
+std::unique_ptr<zenoh::Session> TestZenbeddedHardware::test_router_ = nullptr;
 
-TEST_F(TestZenohZephyrHardware, missing_parameter_fails)
+TEST_F(TestZenbeddedHardware, missing_parameter_fails)
 {
   hardware_interface::HardwareInfo info;
   info.name = "test_hw";
@@ -91,11 +91,11 @@ TEST_F(TestZenohZephyrHardware, missing_parameter_fails)
   hardware_interface::HardwareComponentInterfaceParams params;
   params.hardware_info = info;
 
-  auto hw = std::make_unique<zephyr_zenoh::ZenohZephyrHardware>();
+  auto hw = std::make_unique<zenbedded::ZenbeddedHardware>();
   EXPECT_EQ(hw->on_init(params), CallbackReturn::ERROR);
 }
 
-TEST_F(TestZenohZephyrHardware, state_interfaces_exported)
+TEST_F(TestZenbeddedHardware, state_interfaces_exported)
 {
   auto si = hw_->export_state_interfaces();
   EXPECT_EQ(si.size(), 1);
@@ -103,7 +103,7 @@ TEST_F(TestZenohZephyrHardware, state_interfaces_exported)
   EXPECT_EQ(si[0].get_interface_name(), "position");
 }
 
-TEST_F(TestZenohZephyrHardware, command_interfaces_exported)
+TEST_F(TestZenbeddedHardware, command_interfaces_exported)
 {
   auto ci = hw_->export_command_interfaces();
   EXPECT_EQ(ci.size(), 1);
@@ -111,14 +111,14 @@ TEST_F(TestZenohZephyrHardware, command_interfaces_exported)
   EXPECT_EQ(ci[0].get_interface_name(), "position");
 }
 
-TEST_F(TestZenohZephyrHardware, activate_succeeds_with_router)
+TEST_F(TestZenbeddedHardware, activate_succeeds_with_router)
 {
   rclcpp_lifecycle::State state(1, "unconfigured");
   EXPECT_EQ(hw_->on_activate(state), CallbackReturn::SUCCESS);
   EXPECT_EQ(hw_->on_deactivate(state), CallbackReturn::SUCCESS);
 }
 
-TEST_F(TestZenohZephyrHardware, activate_fails_with_bad_endpoint)
+TEST_F(TestZenbeddedHardware, activate_fails_with_bad_endpoint)
 {
   // Use a port unlikely to be running a Zenoh router
   hardware_interface::HardwareInfo info;
@@ -141,7 +141,7 @@ TEST_F(TestZenohZephyrHardware, activate_fails_with_bad_endpoint)
   hardware_interface::HardwareComponentInterfaceParams params;
   params.hardware_info = info;
 
-  auto hw = std::make_unique<zephyr_zenoh::ZenohZephyrHardware>();
+  auto hw = std::make_unique<zenbedded::ZenbeddedHardware>();
   ASSERT_EQ(hw->on_init(params), CallbackReturn::SUCCESS);
 
   rclcpp_lifecycle::State state(1, "unconfigured");

--- a/zenbedded_hardware_interface/zenbedded_hardware_interface.xml
+++ b/zenbedded_hardware_interface/zenbedded_hardware_interface.xml
@@ -1,6 +1,6 @@
-<library path="zephyr_zenoh_hardware_interface">
-  <class name="zephyr_zenoh_hardware_interface/ZenohZephyrHardware"
-         type="zephyr_zenoh::ZenohZephyrHardware"
+<library path="zenbedded_hardware_interface">
+  <class name="zenbedded_hardware_interface/ZenbeddedHardware"
+         type="zenbedded::ZenbeddedHardware"
          base_class_type="hardware_interface::SystemInterface">
     <description>
       A ros2_control SystemInterface for Zephyr RTOS microcontrollers


### PR DESCRIPTION
Renamed all `zephyr_zenoh` references to `zenbedded` across the package - namespace, class name, package name, include paths, header guards, file names, plugin XML, and test fixtures. No functional changes.