### PR TITLE
[hardware interface] generate C header with packed structs from YAML

### DIFF
--- a/zenbedded_hardware_interface/.gitignore
+++ b/zenbedded_hardware_interface/.gitignore
@@ -1,0 +1,1 @@
+include/*/generated/

--- a/zenbedded_hardware_interface/CMakeLists.txt
+++ b/zenbedded_hardware_interface/CMakeLists.txt
@@ -33,6 +33,33 @@ target_link_libraries(zenbedded_hardware_interface
     yaml-cpp::yaml-cpp
 )
 
+# Schema-driven header generator
+add_executable(generate_header
+  tools/generate_header.cpp
+  src/interface_schema.cpp
+)
+target_link_libraries(generate_header yaml-cpp::yaml-cpp)
+target_include_directories(generate_header PRIVATE include)
+
+set(SCHEMA_YAML "${CMAKE_CURRENT_SOURCE_DIR}/config/interface_schema.yaml")
+set(GENERATED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include/zenbedded_hardware_interface/generated")
+file(MAKE_DIRECTORY ${GENERATED_DIR})
+
+add_custom_command(
+  OUTPUT ${GENERATED_DIR}/interface_data.h
+  COMMAND generate_header
+    --yaml ${SCHEMA_YAML}
+    --output ${GENERATED_DIR}/interface_data.h
+  DEPENDS generate_header ${SCHEMA_YAML}
+  COMMENT "Generating interface_data.h from schema"
+)
+
+add_custom_target(generate_interface_data
+  DEPENDS ${GENERATED_DIR}/interface_data.h
+)
+
+add_dependencies(zenbedded_hardware_interface generate_interface_data)
+
 pluginlib_export_plugin_description_file(hardware_interface zenbedded_hardware_interface.xml)
 
 install(TARGETS zenbedded_hardware_interface DESTINATION lib)
@@ -62,6 +89,10 @@ if(BUILD_TESTING)
   target_include_directories(test_interface_schema PRIVATE
     include
   )
+  target_compile_definitions(test_interface_schema PRIVATE
+    TEST_CONFIG_DIR="${CMAKE_CURRENT_SOURCE_DIR}/config"
+  )
+  add_dependencies(test_interface_schema generate_interface_data)
 endif()
 
 ament_package()

--- a/zenbedded_hardware_interface/config/interface_schema.yaml
+++ b/zenbedded_hardware_interface/config/interface_schema.yaml
@@ -1,0 +1,8 @@
+state_interfaces:
+  motor_arm:
+    position: float32
+  pendulum_axis:
+    position: float32
+command_interfaces:
+  motor_arm:
+    position: float32

--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/interface_schema.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/interface_schema.hpp
@@ -60,6 +60,7 @@ class InterfaceSchema
 {
 public:
   static InterfaceSchema from_yaml(const std::string & yaml_text);
+  static InterfaceSchema from_yaml_file(const std::string & file_path);
 
   bool valid() const { return valid_; }
   std::string error() const { return error_; }
@@ -71,6 +72,8 @@ public:
 
   const auto & state_fields() const { return state_flat_fields_; }
   const auto & command_fields() const { return command_flat_fields_; }
+
+  bool write_c_header(const std::string & output_path) const;
 
 private:
   InterfaceSchema() = default;

--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
@@ -28,6 +28,14 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
+#include "zenbedded_hardware_interface/generated/interface_data.h"
+
+static_assert(
+  sizeof(zenbedded_state_t) == ZENBEDDED_STATE_BYTE_SIZE,
+  "zenbedded_state_t size mismatch with YAML schema");
+static_assert(
+  sizeof(zenbedded_command_t) == ZENBEDDED_COMMAND_BYTE_SIZE,
+  "zenbedded_command_t size mismatch with YAML schema");
 
 namespace zenbedded
 {

--- a/zenbedded_hardware_interface/src/interface_schema.cpp
+++ b/zenbedded_hardware_interface/src/interface_schema.cpp
@@ -15,6 +15,9 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <fstream>
+#include <iterator>
+
 namespace zenbedded
 {
 
@@ -127,6 +130,96 @@ InterfaceSchema InterfaceSchema::from_yaml(const std::string & yaml_text)
   }
 
   return schema;
+}
+
+InterfaceSchema InterfaceSchema::from_yaml_file(const std::string & file_path)
+{
+  std::ifstream file(file_path);
+  if (!file)
+  {
+    InterfaceSchema schema;
+    schema.error_ = "Cannot open file: " + file_path;
+    return schema;
+  }
+  std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  return from_yaml(content);
+}
+
+namespace
+{
+
+const char * field_type_to_c_type(FieldType type)
+{
+  if (type == FieldType::FLOAT32)
+  {
+    return "float";
+  }
+  if (type == FieldType::FLOAT64)
+  {
+    return "double";
+  }
+  if (type == FieldType::INT32)
+  {
+    return "int32_t";
+  }
+  if (type == FieldType::UINT64)
+  {
+    return "uint64_t";
+  }
+  if (type == FieldType::INT16)
+  {
+    return "int16_t";
+  }
+  if (type == FieldType::UINT8)
+  {
+    return "uint8_t";
+  }
+  return "unknown";
+}
+
+}  // namespace
+
+bool InterfaceSchema::write_c_header(const std::string & output_path) const
+{
+  if (!valid_)
+  {
+    return false;
+  }
+
+  std::ofstream out(output_path);
+  if (!out)
+  {
+    return false;
+  }
+
+  const char * guard = "ZENBEDDED_HARDWARE_INTERFACE__GENERATED__INTERFACE_DATA_H_";
+
+  out << "#ifndef " << guard << "\n";
+  out << "#define " << guard << "\n\n";
+  out << "#include <stdint.h>\n\n";
+  out << "#define ZENBEDDED_STATE_BYTE_SIZE " << state_buffer_size_ << "\n";
+  out << "#define ZENBEDDED_COMMAND_BYTE_SIZE " << command_buffer_size_ << "\n\n";
+  out << "#pragma pack(push, 1)\n";
+  out << "typedef struct\n{\n";
+
+  for (const auto & f : state_flat_fields_)
+  {
+    out << "  " << field_type_to_c_type(f.type) << " " << f.component << "_" << f.field << ";\n";
+  }
+
+  out << "} zenbedded_state_t;\n\n";
+  out << "typedef struct\n{\n";
+
+  for (const auto & f : command_flat_fields_)
+  {
+    out << "  " << field_type_to_c_type(f.type) << " " << f.component << "_" << f.field << ";\n";
+  }
+
+  out << "} zenbedded_command_t;\n";
+  out << "#pragma pack(pop)\n\n";
+  out << "#endif  // " << guard << "\n";
+
+  return true;
 }
 
 }  // namespace zenbedded

--- a/zenbedded_hardware_interface/test/test_interface_schema.cpp
+++ b/zenbedded_hardware_interface/test/test_interface_schema.cpp
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <gmock/gmock.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
 #include <string>
 
+#include "zenbedded_hardware_interface/generated/interface_data.h"
 #include "zenbedded_hardware_interface/interface_schema.hpp"
 
 class TestInterfaceSchema : public ::testing::Test
@@ -46,6 +51,55 @@ command_interfaces:
     velocity: float32
 )";
 };
+
+TEST_F(TestInterfaceSchema, generated_state_struct_compiles)
+{
+  EXPECT_GT(sizeof(zenbedded_state_t), 0);
+  EXPECT_GT(ZENBEDDED_STATE_BYTE_SIZE, 0);
+}
+
+TEST_F(TestInterfaceSchema, generated_command_struct_compiles)
+{
+  EXPECT_GT(sizeof(zenbedded_command_t), 0);
+  EXPECT_GT(ZENBEDDED_COMMAND_BYTE_SIZE, 0);
+}
+
+TEST_F(TestInterfaceSchema, generated_struct_sizes_match_config_schema)
+{
+  auto schema = zenbedded::InterfaceSchema::from_yaml_file(
+    std::string(TEST_CONFIG_DIR) + "/interface_schema.yaml");
+  ASSERT_TRUE(schema.valid()) << schema.error();
+  EXPECT_EQ(sizeof(zenbedded_state_t), ZENBEDDED_STATE_BYTE_SIZE);
+  EXPECT_EQ(sizeof(zenbedded_state_t), schema.state_buffer_size());
+  EXPECT_EQ(sizeof(zenbedded_command_t), ZENBEDDED_COMMAND_BYTE_SIZE);
+  EXPECT_EQ(sizeof(zenbedded_command_t), schema.command_buffer_size());
+}
+
+TEST_F(TestInterfaceSchema, write_c_header_produces_valid_output)
+{
+  auto schema = zenbedded::InterfaceSchema::from_yaml(multi_field_yaml);
+  ASSERT_TRUE(schema.valid());
+
+  char tmp_path[] = "/tmp/test_header_XXXXXX";
+  int fd = mkstemp(tmp_path);
+  ASSERT_GE(fd, 0);
+  close(fd);
+
+  EXPECT_TRUE(schema.write_c_header(tmp_path));
+
+  std::ifstream file(tmp_path);
+  ASSERT_TRUE(file.is_open());
+  std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  file.close();
+  std::remove(tmp_path);
+
+  EXPECT_THAT(content, ::testing::HasSubstr("zenbedded_state_t"));
+  EXPECT_THAT(content, ::testing::HasSubstr("zenbedded_command_t"));
+  EXPECT_THAT(content, ::testing::HasSubstr("ZENBEDDED_STATE_BYTE_SIZE"));
+  EXPECT_THAT(content, ::testing::HasSubstr("ZENBEDDED_COMMAND_BYTE_SIZE"));
+  EXPECT_THAT(content, ::testing::HasSubstr("left_wheel_position"));
+  EXPECT_THAT(content, ::testing::HasSubstr("right_wheel_velocity"));
+}
 
 TEST_F(TestInterfaceSchema, simple_schema)
 {
@@ -95,4 +149,13 @@ TEST_F(TestInterfaceSchema, invalid_yaml_fails)
   auto schema = zenbedded::InterfaceSchema::from_yaml("{invalid: [yaml");
   EXPECT_FALSE(schema.valid());
   EXPECT_FALSE(schema.error().empty());
+}
+
+TEST_F(TestInterfaceSchema, unknown_type_fails)
+{
+  auto schema = zenbedded::InterfaceSchema::from_yaml(
+    "state_interfaces:\n  j:\n    p: float33\n"
+    "command_interfaces:\n  j:\n    p: float32\n");
+  EXPECT_FALSE(schema.valid());
+  EXPECT_THAT(schema.error(), ::testing::HasSubstr("Unknown type"));
 }

--- a/zenbedded_hardware_interface/tools/generate_header.cpp
+++ b/zenbedded_hardware_interface/tools/generate_header.cpp
@@ -1,0 +1,60 @@
+// Copyright 2026 kamal2730
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "zenbedded_hardware_interface/interface_schema.hpp"
+
+int main(int argc, char * argv[])
+{
+  std::string yaml_path;
+  std::string output_path;
+
+  for (int i = 1; i < argc; ++i)
+  {
+    std::string arg = argv[i];
+    if (arg == "--yaml" && i + 1 < argc)
+    {
+      yaml_path = argv[++i];
+    }
+    else if (arg == "--output" && i + 1 < argc)
+    {
+      output_path = argv[++i];
+    }
+  }
+
+  if (yaml_path.empty() || output_path.empty())
+  {
+    std::cerr << "Usage: generate_header --yaml <schema.yaml> --output <output.h>\n";
+    return EXIT_FAILURE;
+  }
+
+  auto schema = zenbedded::InterfaceSchema::from_yaml_file(yaml_path);
+  if (!schema.valid())
+  {
+    std::cerr << "Schema error: " << schema.error() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  if (!schema.write_c_header(output_path))
+  {
+    std::cerr << "Failed to write header: " << output_path << "\n";
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "Generated " << output_path << "\n";
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

The current PR generates C header files from the provided interface YAML. These generated headers define packed C structs representing the state and command interfaces, along with their corresponding byte sizes.

### Example 1

**YAML**

```yaml
state_interfaces:
  motor_arm:
    position: float32
  pendulum_axis:
    position: float32

command_interfaces:
  motor_arm:
    position: float32
```

**Generated Header**

```cpp
#ifndef ZENBEDDED_HARDWARE_INTERFACE__GENERATED__INTERFACE_DATA_H_
#define ZENBEDDED_HARDWARE_INTERFACE__GENERATED__INTERFACE_DATA_H_

#include <stdint.h>

#define ZENBEDDED_STATE_BYTE_SIZE 8
#define ZENBEDDED_COMMAND_BYTE_SIZE 4

#pragma pack(push, 1)
typedef struct
{
  float motor_arm_position;
  float pendulum_axis_position;
} zenbedded_state_t;

typedef struct
{
  float motor_arm_position;
} zenbedded_command_t;
#pragma pack(pop)

#endif  // ZENBEDDED_HARDWARE_INTERFACE__GENERATED__INTERFACE_DATA_H_
```

---

### Example 2

**YAML**

```yaml
state_interfaces:
  sensor:
    temperature: float32
    voltage: float64
    counter: int32
    timestamp: uint64
    short_val: int16
    flags: uint8

command_interfaces:
  actuator:
    position: float32
    velocity: float64
```

**Generated Header**

```cpp
#ifndef ZENBEDDED_HARDWARE_INTERFACE__GENERATED__INTERFACE_DATA_H_
#define ZENBEDDED_HARDWARE_INTERFACE__GENERATED__INTERFACE_DATA_H_

#include <stdint.h>

#define ZENBEDDED_STATE_BYTE_SIZE 27
#define ZENBEDDED_COMMAND_BYTE_SIZE 12

#pragma pack(push, 1)
typedef struct
{
  float sensor_temperature;
  double sensor_voltage;
  int32_t sensor_counter;
  uint64_t sensor_timestamp;
  int16_t sensor_short_val;
  uint8_t sensor_flags;
} zenbedded_state_t;

typedef struct
{
  float actuator_position;
  double actuator_velocity;
} zenbedded_command_t;
#pragma pack(pop)

#endif  // ZENBEDDED_HARDWARE_INTERFACE__GENERATED__INTERFACE_DATA_H_
```

## Next PR

In the current PR, these custom-generated headers are included in `zenbedded_hardware.hpp`.

In the next PR, the generated structs (`zenbedded_state_t` and `zenbedded_command_t`) will be used in the `read()` and `write()` methods to pack and unpack the binary payloads using the `InterfaceSchema` class. 