### PR TITLE
[hardware interface] add lock-free read()/write() and add tests

### DIFF
--- a/zenbedded_hardware_interface/CMakeLists.txt
+++ b/zenbedded_hardware_interface/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(zenoh_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
+find_package(realtime_tools REQUIRED)
 
 add_library(zenbedded_hardware_interface SHARED
   src/zenbedded_hardware.cpp
@@ -31,6 +32,7 @@ target_link_libraries(zenbedded_hardware_interface
     rclcpp_lifecycle::rclcpp_lifecycle
     zenohcxx::zenohc
     yaml-cpp::yaml-cpp
+    realtime_tools::realtime_tools
 )
 
 # Schema-driven header generator
@@ -58,8 +60,6 @@ add_custom_target(generate_interface_data
   DEPENDS ${GENERATED_DIR}/interface_data.h
 )
 
-add_dependencies(zenbedded_hardware_interface generate_interface_data)
-
 pluginlib_export_plugin_description_file(hardware_interface zenbedded_hardware_interface.xml)
 
 install(TARGETS zenbedded_hardware_interface DESTINATION lib)
@@ -79,6 +79,10 @@ if(BUILD_TESTING)
   target_include_directories(test_zenbedded_hardware PRIVATE
     include
   )
+  target_compile_definitions(test_zenbedded_hardware PRIVATE
+    TEST_CONFIG_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test/config"
+  )
+  add_dependencies(test_zenbedded_hardware generate_interface_data)
   ament_add_gmock(test_interface_schema
     test/test_interface_schema.cpp
   )

--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/interface_schema.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/interface_schema.hpp
@@ -23,12 +23,12 @@ namespace zenbedded
 
 enum class FieldType : uint8_t
 {
-  FLOAT32 = 4,
-  FLOAT64 = 8,
-  INT32 = 4,
-  UINT64 = 8,
-  INT16 = 2,
-  UINT8 = 1,
+  FLOAT32,
+  FLOAT64,
+  INT32,
+  UINT64,
+  INT16,
+  UINT8,
 };
 
 struct FieldDescriptor
@@ -75,7 +75,12 @@ public:
 
   bool write_c_header(const std::string & output_path) const;
 
-private:
+  double read_state_field(const uint8_t * buffer, size_t field_index) const;
+  double read_command_field(const uint8_t * buffer, size_t field_index) const;
+  void write_command_field(uint8_t * buffer, size_t field_index, double value) const;
+
+  static size_t field_byte_size(FieldType type);
+
   InterfaceSchema() = default;
 
   bool valid_ = false;

--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
@@ -15,11 +15,13 @@
 #ifndef ZENBEDDED_HARDWARE_INTERFACE__ZENBEDDED_HARDWARE_HPP_
 #define ZENBEDDED_HARDWARE_INTERFACE__ZENBEDDED_HARDWARE_HPP_
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 
+#include <realtime_tools/realtime_buffer.hpp>
 #include <zenoh.hxx>
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
@@ -28,14 +30,7 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
-#include "zenbedded_hardware_interface/generated/interface_data.h"
-
-static_assert(
-  sizeof(zenbedded_state_t) == ZENBEDDED_STATE_BYTE_SIZE,
-  "zenbedded_state_t size mismatch with YAML schema");
-static_assert(
-  sizeof(zenbedded_command_t) == ZENBEDDED_COMMAND_BYTE_SIZE,
-  "zenbedded_command_t size mismatch with YAML schema");
+#include "zenbedded_hardware_interface/interface_schema.hpp"
 
 namespace zenbedded
 {
@@ -65,10 +60,19 @@ public:
 
 private:
   std::unique_ptr<zenoh::Session> session_;
+
+  InterfaceSchema schema_;
+
+  // Lock-free state buffer
+  realtime_tools::RealtimeBuffer<std::vector<uint8_t>> state_buffer_;
+  std::vector<uint8_t> command_buffer_;
+
+  // Zenoh sub/pub
+  std::unique_ptr<zenoh::Subscriber<void>> state_sub_;
+  std::unique_ptr<zenoh::Publisher> command_pub_;
+
   std::vector<double> hw_commands_;
   std::vector<double> hw_states_;
-  std::vector<double> hw_state_buffer_;
-  mutable std::mutex data_mutex_;
   std::string zenoh_endpoint_;
   std::string zenoh_mode_;
   std::string state_topic_;

--- a/zenbedded_hardware_interface/package.xml
+++ b/zenbedded_hardware_interface/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>zenoh_cpp_vendor</depend>
   <depend>yaml_cpp_vendor</depend>
+  <depend>realtime_tools</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/zenbedded_hardware_interface/src/interface_schema.cpp
+++ b/zenbedded_hardware_interface/src/interface_schema.cpp
@@ -15,6 +15,7 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <cstring>
 #include <fstream>
 #include <iterator>
 
@@ -67,7 +68,7 @@ bool parse_component_fields(
       return false;
     }
 
-    size_t byte_size = static_cast<size_t>(type);
+    size_t byte_size = InterfaceSchema::field_byte_size(type);
     fields.push_back({component_name, field_name, type, buffer_size});
     buffer_size += byte_size;
   }
@@ -220,6 +221,167 @@ bool InterfaceSchema::write_c_header(const std::string & output_path) const
   out << "#endif  // " << guard << "\n";
 
   return true;
+}
+
+size_t InterfaceSchema::field_byte_size(FieldType type)
+{
+  if (type == FieldType::FLOAT32)
+  {
+    return 4;
+  }
+  if (type == FieldType::FLOAT64)
+  {
+    return 8;
+  }
+  if (type == FieldType::INT32)
+  {
+    return 4;
+  }
+  if (type == FieldType::UINT64)
+  {
+    return 8;
+  }
+  if (type == FieldType::INT16)
+  {
+    return 2;
+  }
+  if (type == FieldType::UINT8)
+  {
+    return 1;
+  }
+  return 0;
+}
+
+double InterfaceSchema::read_state_field(const uint8_t * buffer, size_t field_index) const
+{
+  if (field_index >= state_flat_fields_.size())
+  {
+    return 0.0;
+  }
+  const auto & f = state_flat_fields_[field_index];
+  double value = 0.0;
+  if (f.type == FieldType::FLOAT32)
+  {
+    float v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(float));
+    value = static_cast<double>(v);
+  }
+  else if (f.type == FieldType::FLOAT64)
+  {
+    double v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(double));
+    value = v;
+  }
+  else if (f.type == FieldType::INT32)
+  {
+    int32_t v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(int32_t));
+    value = static_cast<double>(v);
+  }
+  else if (f.type == FieldType::UINT64)
+  {
+    uint64_t v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(uint64_t));
+    value = static_cast<double>(v);
+  }
+  else if (f.type == FieldType::INT16)
+  {
+    int16_t v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(int16_t));
+    value = static_cast<double>(v);
+  }
+  else if (f.type == FieldType::UINT8)
+  {
+    uint8_t v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(uint8_t));
+    value = static_cast<double>(v);
+  }
+  return value;
+}
+
+double InterfaceSchema::read_command_field(const uint8_t * buffer, size_t field_index) const
+{
+  if (field_index >= command_flat_fields_.size())
+  {
+    return 0.0;
+  }
+  const auto & f = command_flat_fields_[field_index];
+  double value = 0.0;
+  if (f.type == FieldType::FLOAT32)
+  {
+    float v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(float));
+    value = static_cast<double>(v);
+  }
+  else if (f.type == FieldType::FLOAT64)
+  {
+    double v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(double));
+    value = v;
+  }
+  else if (f.type == FieldType::INT32)
+  {
+    int32_t v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(int32_t));
+    value = static_cast<double>(v);
+  }
+  else if (f.type == FieldType::UINT64)
+  {
+    uint64_t v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(uint64_t));
+    value = static_cast<double>(v);
+  }
+  else if (f.type == FieldType::INT16)
+  {
+    int16_t v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(int16_t));
+    value = static_cast<double>(v);
+  }
+  else if (f.type == FieldType::UINT8)
+  {
+    uint8_t v;
+    std::memcpy(&v, buffer + f.byte_offset, sizeof(uint8_t));
+    value = static_cast<double>(v);
+  }
+  return value;
+}
+
+void InterfaceSchema::write_command_field(uint8_t * buffer, size_t field_index, double value) const
+{
+  if (field_index >= command_flat_fields_.size())
+  {
+    return;
+  }
+  const auto & f = command_flat_fields_[field_index];
+  if (f.type == FieldType::FLOAT32)
+  {
+    float v = static_cast<float>(value);
+    std::memcpy(buffer + f.byte_offset, &v, sizeof(float));
+  }
+  else if (f.type == FieldType::FLOAT64)
+  {
+    std::memcpy(buffer + f.byte_offset, &value, sizeof(double));
+  }
+  else if (f.type == FieldType::INT32)
+  {
+    int32_t v = static_cast<int32_t>(value);
+    std::memcpy(buffer + f.byte_offset, &v, sizeof(int32_t));
+  }
+  else if (f.type == FieldType::UINT64)
+  {
+    uint64_t v = static_cast<uint64_t>(value);
+    std::memcpy(buffer + f.byte_offset, &v, sizeof(uint64_t));
+  }
+  else if (f.type == FieldType::INT16)
+  {
+    int16_t v = static_cast<int16_t>(value);
+    std::memcpy(buffer + f.byte_offset, &v, sizeof(int16_t));
+  }
+  else if (f.type == FieldType::UINT8)
+  {
+    uint8_t v = static_cast<uint8_t>(value);
+    std::memcpy(buffer + f.byte_offset, &v, sizeof(uint8_t));
+  }
 }
 
 }  // namespace zenbedded

--- a/zenbedded_hardware_interface/src/zenbedded_hardware.cpp
+++ b/zenbedded_hardware_interface/src/zenbedded_hardware.cpp
@@ -18,10 +18,11 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "zenbedded_hardware_interface/interface_schema.hpp"
 
 namespace zenbedded
 {
@@ -49,9 +50,31 @@ CallbackReturn ZenbeddedHardware::on_init(
     return CallbackReturn::ERROR;
   }
 
-  hw_states_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
-  hw_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
-  hw_state_buffer_.resize(info_.joints.size(), 0.0);
+  // Load required schema
+  std::string schema_path;
+  try
+  {
+    schema_path = info_.hardware_parameters.at("schema_path");
+  }
+  catch (const std::out_of_range &)
+  {
+    RCLCPP_FATAL(
+      rclcpp::get_logger("ZenbeddedHardware"), "Missing required URDF parameter: schema_path");
+    return CallbackReturn::ERROR;
+  }
+
+  schema_ = InterfaceSchema::from_yaml_file(schema_path);
+  if (!schema_.valid())
+  {
+    RCLCPP_FATAL(
+      rclcpp::get_logger("ZenbeddedHardware"), "Schema error: %s", schema_.error().c_str());
+    return CallbackReturn::ERROR;
+  }
+
+  hw_states_.resize(schema_.total_state_interfaces(), std::numeric_limits<double>::quiet_NaN());
+  hw_commands_.resize(schema_.total_command_interfaces(), std::numeric_limits<double>::quiet_NaN());
+  state_buffer_.writeFromNonRT(std::vector<uint8_t>(schema_.state_buffer_size(), 0));
+  command_buffer_.resize(schema_.command_buffer_size(), 0);
 
   RCLCPP_INFO(rclcpp::get_logger("ZenbeddedHardware"), "Hardware Interface Initialized!");
   return CallbackReturn::SUCCESS;
@@ -60,11 +83,10 @@ CallbackReturn ZenbeddedHardware::on_init(
 std::vector<hardware_interface::StateInterface> ZenbeddedHardware::export_state_interfaces()
 {
   std::vector<hardware_interface::StateInterface> state_interfaces;
-  for (size_t i = 0; i < info_.joints.size(); i++)
+  for (size_t i = 0; i < schema_.state_fields().size(); i++)
   {
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_states_[i]));
+    const auto & f = schema_.state_fields()[i];
+    state_interfaces.emplace_back(f.component, f.field, &hw_states_[i]);
   }
   return state_interfaces;
 }
@@ -72,11 +94,10 @@ std::vector<hardware_interface::StateInterface> ZenbeddedHardware::export_state_
 std::vector<hardware_interface::CommandInterface> ZenbeddedHardware::export_command_interfaces()
 {
   std::vector<hardware_interface::CommandInterface> command_interfaces;
-  for (size_t i = 0; i < info_.joints.size(); i++)
+  for (size_t i = 0; i < schema_.command_fields().size(); i++)
   {
-    command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_commands_[i]));
+    const auto & f = schema_.command_fields()[i];
+    command_interfaces.emplace_back(f.component, f.field, &hw_commands_[i]);
   }
   return command_interfaces;
 }
@@ -89,6 +110,18 @@ CallbackReturn ZenbeddedHardware::on_activate(const rclcpp_lifecycle::State & /*
     config.insert_json5("connect/endpoints", "[\"" + zenoh_endpoint_ + "\"]");
     config.insert_json5("mode", "\"" + zenoh_mode_ + "\"");
     session_ = std::make_unique<zenoh::Session>(std::move(config));
+
+    state_sub_ = std::make_unique<zenoh::Subscriber<void>>(session_->declare_subscriber(
+      zenoh::KeyExpr(state_topic_),
+      [this](zenoh::Sample & sample)
+      {
+        const auto & payload = sample.get_payload();
+        state_buffer_.writeFromNonRT(payload.as_vector());
+      },
+      []() {}, zenoh::Session::SubscriberOptions::create_default(), nullptr));
+
+    command_pub_ = std::make_unique<zenoh::Publisher>(session_->declare_publisher(
+      zenoh::KeyExpr(command_topic_), zenoh::Session::PublisherOptions::create_default(), nullptr));
 
     for (size_t i = 0; i < hw_states_.size(); i++)
     {
@@ -110,6 +143,8 @@ CallbackReturn ZenbeddedHardware::on_activate(const rclcpp_lifecycle::State & /*
 
 CallbackReturn ZenbeddedHardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  state_sub_.reset();
+  command_pub_.reset();
   session_.reset();
   RCLCPP_INFO(rclcpp::get_logger("ZenbeddedHardware"), "Hardware deactivated.");
   return CallbackReturn::SUCCESS;
@@ -118,10 +153,13 @@ CallbackReturn ZenbeddedHardware::on_deactivate(const rclcpp_lifecycle::State & 
 hardware_interface::return_type ZenbeddedHardware::read(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
-  std::lock_guard<std::mutex> lock(data_mutex_);
-  for (size_t i = 0; i < hw_states_.size(); i++)
+  auto buf = state_buffer_.readFromRT();
+  if (buf)
   {
-    hw_states_[i] = hw_state_buffer_[i];
+    for (size_t i = 0; i < schema_.total_state_interfaces(); i++)
+    {
+      hw_states_[i] = schema_.read_state_field(buf->data(), i);
+    }
   }
   return hardware_interface::return_type::OK;
 }
@@ -129,11 +167,11 @@ hardware_interface::return_type ZenbeddedHardware::read(
 hardware_interface::return_type ZenbeddedHardware::write(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
-  std::lock_guard<std::mutex> lock(data_mutex_);
-  for (size_t i = 0; i < hw_commands_.size(); i++)
+  for (size_t i = 0; i < schema_.total_command_interfaces(); i++)
   {
-    hw_state_buffer_[i] = hw_commands_[i];
+    schema_.write_command_field(command_buffer_.data(), i, hw_commands_[i]);
   }
+  command_pub_->put(command_buffer_);
   return hardware_interface::return_type::OK;
 }
 

--- a/zenbedded_hardware_interface/test/config/instance_arm.yaml
+++ b/zenbedded_hardware_interface/test/config/instance_arm.yaml
@@ -1,0 +1,11 @@
+state_interfaces:
+  shoulder:
+    position: float32
+    velocity: float32
+  elbow:
+    position: float32
+command_interfaces:
+  shoulder:
+    position: float32
+  elbow:
+    position: float32

--- a/zenbedded_hardware_interface/test/config/instance_gripper.yaml
+++ b/zenbedded_hardware_interface/test/config/instance_gripper.yaml
@@ -1,0 +1,6 @@
+state_interfaces:
+  gripper:
+    position: float32
+command_interfaces:
+  gripper:
+    position: float32

--- a/zenbedded_hardware_interface/test/config/interface_schema.yaml
+++ b/zenbedded_hardware_interface/test/config/interface_schema.yaml
@@ -1,0 +1,8 @@
+state_interfaces:
+  motor_arm:
+    position: float32
+  pendulum_axis:
+    position: float32
+command_interfaces:
+  motor_arm:
+    position: float32

--- a/zenbedded_hardware_interface/test/test_interface_schema.cpp
+++ b/zenbedded_hardware_interface/test/test_interface_schema.cpp
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <string>
 
@@ -49,6 +50,25 @@ command_interfaces:
     velocity: float32
   right_wheel:
     velocity: float32
+)";
+
+  static constexpr const char * all_types_yaml = R"(
+state_interfaces:
+  all_types:
+    f32: float32
+    f64: float64
+    i32: int32
+    u64: uint64
+    i16: int16
+    u8: uint8
+command_interfaces:
+  all_types:
+    f32: float32
+    f64: float64
+    i32: int32
+    u64: uint64
+    i16: int16
+    u8: uint8
 )";
 };
 
@@ -158,4 +178,105 @@ TEST_F(TestInterfaceSchema, unknown_type_fails)
     "command_interfaces:\n  j:\n    p: float32\n");
   EXPECT_FALSE(schema.valid());
   EXPECT_THAT(schema.error(), ::testing::HasSubstr("Unknown type"));
+}
+
+TEST_F(TestInterfaceSchema, read_state_field_all_types)
+{
+  auto schema = zenbedded::InterfaceSchema::from_yaml(all_types_yaml);
+  ASSERT_TRUE(schema.valid());
+
+  std::vector<uint8_t> buf(schema.state_buffer_size(), 0);
+
+  float f32_val = 3.14f;
+  double f64_val = 2.718;
+  int32_t i32_val = -42;
+  uint64_t u64_val = 123456789;
+  int16_t i16_val = -1000;
+  uint8_t u8_val = 200;
+
+  std::memcpy(buf.data(), &f32_val, 4);
+  std::memcpy(buf.data() + 4, &f64_val, 8);
+  std::memcpy(buf.data() + 12, &i32_val, 4);
+  std::memcpy(buf.data() + 16, &u64_val, 8);
+  std::memcpy(buf.data() + 24, &i16_val, 2);
+  std::memcpy(buf.data() + 26, &u8_val, 1);
+
+  EXPECT_DOUBLE_EQ(schema.read_state_field(buf.data(), 0), static_cast<double>(f32_val));
+  EXPECT_DOUBLE_EQ(schema.read_state_field(buf.data(), 1), f64_val);
+  EXPECT_DOUBLE_EQ(schema.read_state_field(buf.data(), 2), static_cast<double>(i32_val));
+  EXPECT_DOUBLE_EQ(schema.read_state_field(buf.data(), 3), static_cast<double>(u64_val));
+  EXPECT_DOUBLE_EQ(schema.read_state_field(buf.data(), 4), static_cast<double>(i16_val));
+  EXPECT_DOUBLE_EQ(schema.read_state_field(buf.data(), 5), static_cast<double>(u8_val));
+}
+
+TEST_F(TestInterfaceSchema, read_state_field_out_of_range_returns_zero)
+{
+  auto schema = zenbedded::InterfaceSchema::from_yaml(simple_yaml);
+  ASSERT_TRUE(schema.valid());
+  uint8_t dummy = 0;
+  EXPECT_DOUBLE_EQ(schema.read_state_field(&dummy, 999), 0.0);
+}
+
+TEST_F(TestInterfaceSchema, read_command_field_all_types)
+{
+  auto schema = zenbedded::InterfaceSchema::from_yaml(all_types_yaml);
+  ASSERT_TRUE(schema.valid());
+  EXPECT_EQ(schema.total_command_interfaces(), 6);
+
+  std::vector<uint8_t> buf(schema.command_buffer_size(), 0);
+
+  float f32_val = 1.5f;
+  double f64_val = 2.71828;
+  int32_t i32_val = -99;
+  uint64_t u64_val = 999888777;
+  int16_t i16_val = -5;
+  uint8_t u8_val = 12;
+
+  std::memcpy(buf.data(), &f32_val, 4);
+  std::memcpy(buf.data() + 4, &f64_val, 8);
+  std::memcpy(buf.data() + 12, &i32_val, 4);
+  std::memcpy(buf.data() + 16, &u64_val, 8);
+  std::memcpy(buf.data() + 24, &i16_val, 2);
+  std::memcpy(buf.data() + 26, &u8_val, 1);
+
+  EXPECT_DOUBLE_EQ(schema.read_command_field(buf.data(), 0), static_cast<double>(f32_val));
+  EXPECT_DOUBLE_EQ(schema.read_command_field(buf.data(), 1), f64_val);
+  EXPECT_DOUBLE_EQ(schema.read_command_field(buf.data(), 2), static_cast<double>(i32_val));
+  EXPECT_DOUBLE_EQ(schema.read_command_field(buf.data(), 3), static_cast<double>(u64_val));
+  EXPECT_DOUBLE_EQ(schema.read_command_field(buf.data(), 4), static_cast<double>(i16_val));
+  EXPECT_DOUBLE_EQ(schema.read_command_field(buf.data(), 5), static_cast<double>(u8_val));
+}
+
+TEST_F(TestInterfaceSchema, write_command_field_all_types)
+{
+  auto schema = zenbedded::InterfaceSchema::from_yaml(all_types_yaml);
+  ASSERT_TRUE(schema.valid());
+
+  std::vector<uint8_t> buf(schema.command_buffer_size(), 0);
+
+  schema.write_command_field(buf.data(), 0, 1.5);
+  schema.write_command_field(buf.data(), 1, 2.5);
+  schema.write_command_field(buf.data(), 2, -99.0);
+  schema.write_command_field(buf.data(), 3, 999.0);
+  schema.write_command_field(buf.data(), 4, -5.0);
+  schema.write_command_field(buf.data(), 5, 12.0);
+
+  float f32_out;
+  std::memcpy(&f32_out, buf.data(), 4);
+  EXPECT_FLOAT_EQ(f32_out, 1.5f);
+  double f64_out;
+  std::memcpy(&f64_out, buf.data() + 4, 8);
+  EXPECT_DOUBLE_EQ(f64_out, 2.5);
+  int32_t i32_out;
+  std::memcpy(&i32_out, buf.data() + 12, 4);
+  EXPECT_EQ(i32_out, -99);
+  uint64_t u64_out;
+  std::memcpy(&u64_out, buf.data() + 16, 8);
+  EXPECT_EQ(u64_out, 999);
+  int16_t i16_out;
+  std::memcpy(&i16_out, buf.data() + 24, 2);
+  EXPECT_EQ(i16_out, -5);
+  uint8_t u8_out;
+  std::memcpy(&u8_out, buf.data() + 26, 1);
+  EXPECT_EQ(u8_out, 12);
 }

--- a/zenbedded_hardware_interface/test/test_zenbedded_hardware.cpp
+++ b/zenbedded_hardware_interface/test/test_zenbedded_hardware.cpp
@@ -13,13 +13,16 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
+#include <chrono>
+#include <cstring>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <rclcpp_lifecycle/state.hpp>
 #include <zenoh.hxx>
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "zenbedded_hardware_interface/generated/interface_data.h"
 #include "zenbedded_hardware_interface/zenbedded_hardware.hpp"
 
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
@@ -40,24 +43,14 @@ protected:
 
   void SetUp() override
   {
-    // Build HardwareComponentInterfaceParams with test data
     hardware_interface::HardwareInfo info;
     info.name = "test_hw";
     info.hardware_parameters["zenoh_endpoint"] = "tcp/127.0.0.1:21555";
     info.hardware_parameters["state_topic"] = "joint_states";
     info.hardware_parameters["command_topic"] = "joint_commands";
     info.hardware_parameters["zenoh_mode"] = "client";
-
-    hardware_interface::ComponentInfo joint;
-    joint.name = "test_joint";
-    hardware_interface::InterfaceInfo si;
-    si.name = "position";
-    joint.state_interfaces.push_back(si);
-
-    hardware_interface::InterfaceInfo ci;
-    ci.name = "position";
-    joint.command_interfaces.push_back(ci);
-    info.joints.push_back(joint);
+    info.hardware_parameters["schema_path"] =
+      std::string(TEST_CONFIG_DIR) + "/interface_schema.yaml";
 
     hardware_interface::HardwareComponentInterfaceParams params;
     params.hardware_info = info;
@@ -72,21 +65,28 @@ protected:
 
 std::unique_ptr<zenoh::Session> TestZenbeddedHardware::test_router_ = nullptr;
 
-TEST_F(TestZenbeddedHardware, missing_parameter_fails)
+TEST_F(TestZenbeddedHardware, missing_schema_path_fails)
+{
+  hardware_interface::HardwareInfo info;
+  info.name = "test_hw";
+  info.hardware_parameters["zenoh_endpoint"] = "tcp/127.0.0.1:21555";
+  info.hardware_parameters["state_topic"] = "joint_states";
+  info.hardware_parameters["command_topic"] = "joint_commands";
+  // Intentionally NOT setting schema_path
+
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = info;
+
+  auto hw = std::make_unique<zenbedded::ZenbeddedHardware>();
+  EXPECT_EQ(hw->on_init(params), CallbackReturn::ERROR);
+}
+
+TEST_F(TestZenbeddedHardware, missing_zenoh_params_fails)
 {
   hardware_interface::HardwareInfo info;
   info.name = "test_hw";
   // Intentionally NOT setting zenoh_endpoint, state_topic, command_topic
-  hardware_interface::ComponentInfo joint;
-  joint.name = "test_joint";
-  hardware_interface::InterfaceInfo si;
-  si.name = "position";
-  joint.state_interfaces.push_back(si);
-
-  hardware_interface::InterfaceInfo ci;
-  ci.name = "position";
-  joint.command_interfaces.push_back(ci);
-  info.joints.push_back(joint);
+  info.hardware_parameters["schema_path"] = std::string(TEST_CONFIG_DIR) + "/interface_schema.yaml";
 
   hardware_interface::HardwareComponentInterfaceParams params;
   params.hardware_info = info;
@@ -98,16 +98,17 @@ TEST_F(TestZenbeddedHardware, missing_parameter_fails)
 TEST_F(TestZenbeddedHardware, state_interfaces_exported)
 {
   auto si = hw_->export_state_interfaces();
-  EXPECT_EQ(si.size(), 1);
-  EXPECT_EQ(si[0].get_name(), "test_joint/position");
+  EXPECT_EQ(si.size(), 2);
+  EXPECT_EQ(si[0].get_name(), "motor_arm/position");
   EXPECT_EQ(si[0].get_interface_name(), "position");
+  EXPECT_EQ(si[1].get_name(), "pendulum_axis/position");
 }
 
 TEST_F(TestZenbeddedHardware, command_interfaces_exported)
 {
   auto ci = hw_->export_command_interfaces();
   EXPECT_EQ(ci.size(), 1);
-  EXPECT_EQ(ci[0].get_name(), "test_joint/position");
+  EXPECT_EQ(ci[0].get_name(), "motor_arm/position");
   EXPECT_EQ(ci[0].get_interface_name(), "position");
 }
 
@@ -128,15 +129,7 @@ TEST_F(TestZenbeddedHardware, activate_fails_with_bad_endpoint)
   info.hardware_parameters["command_topic"] = "joint_commands";
   info.hardware_parameters["zenoh_mode"] = "client";
 
-  hardware_interface::ComponentInfo joint;
-  joint.name = "test_joint";
-  hardware_interface::InterfaceInfo si;
-  si.name = "position";
-  joint.state_interfaces.push_back(si);
-  hardware_interface::InterfaceInfo ci;
-  ci.name = "position";
-  joint.command_interfaces.push_back(ci);
-  info.joints.push_back(joint);
+  info.hardware_parameters["schema_path"] = std::string(TEST_CONFIG_DIR) + "/interface_schema.yaml";
 
   hardware_interface::HardwareComponentInterfaceParams params;
   params.hardware_info = info;
@@ -146,4 +139,222 @@ TEST_F(TestZenbeddedHardware, activate_fails_with_bad_endpoint)
 
   rclcpp_lifecycle::State state(1, "unconfigured");
   EXPECT_EQ(hw->on_activate(state), CallbackReturn::ERROR);
+}
+
+TEST_F(TestZenbeddedHardware, read_state_updates_hw_states)
+{
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  ASSERT_EQ(hw_->on_activate(state), CallbackReturn::SUCCESS);
+
+  zenbedded_state_t state_data;
+  state_data.motor_arm_position = 3.14f;
+  state_data.pendulum_axis_position = 2.71f;
+
+  auto buf = std::vector<uint8_t>(
+    reinterpret_cast<const uint8_t *>(&state_data),
+    reinterpret_cast<const uint8_t *>(&state_data) + sizeof(zenbedded_state_t));
+
+  // Retry loop: publish and read until data arrives or timeout
+  bool received = false;
+  for (int attempt = 0; attempt < 5; attempt++)
+  {
+    test_router_->put(zenoh::KeyExpr("joint_states"), buf);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    EXPECT_EQ(
+      hw_->read(rclcpp::Time(0), rclcpp::Duration(0, 0)), hardware_interface::return_type::OK);
+
+    auto si = hw_->export_state_interfaces();
+    if (
+      si.size() >= 2 &&
+      std::abs(static_cast<float>(si[0].get_optional().value_or(0)) - 3.14f) < 0.001f)
+    {
+      received = true;
+      break;
+    }
+  }
+
+  ASSERT_TRUE(received);
+
+  auto si = hw_->export_state_interfaces();
+  EXPECT_FLOAT_EQ(static_cast<float>(si[0].get_optional().value()), 3.14f);
+  EXPECT_FLOAT_EQ(static_cast<float>(si[1].get_optional().value()), 2.71f);
+
+  EXPECT_EQ(hw_->on_deactivate(state), CallbackReturn::SUCCESS);
+}
+
+TEST_F(TestZenbeddedHardware, write_publishes_command_via_zenoh)
+{
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  ASSERT_EQ(hw_->on_activate(state), CallbackReturn::SUCCESS);
+
+  // Subscribe on command topic via test_router_ to capture published data
+  std::vector<uint8_t> received;
+  auto sub = test_router_->declare_subscriber(
+    zenoh::KeyExpr("joint_commands"),
+    [&](zenoh::Sample & sample) { received = sample.get_payload().as_vector(); }, []() {},
+    zenoh::Session::SubscriberOptions::create_default(), nullptr);
+
+  auto ci = hw_->export_command_interfaces();
+  ASSERT_GE(ci.size(), 1);
+  ASSERT_TRUE(ci[0].set_value(1.5));
+
+  // Retry loop: write and check until data arrives or timeout
+  bool published = false;
+  for (int attempt = 0; attempt < 5; attempt++)
+  {
+    EXPECT_EQ(
+      hw_->write(rclcpp::Time(0), rclcpp::Duration(0, 0)), hardware_interface::return_type::OK);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    if (received.size() == 4)
+    {
+      published = true;
+      break;
+    }
+  }
+
+  ASSERT_TRUE(published);
+  ASSERT_EQ(received.size(), sizeof(zenbedded_command_t));
+  zenbedded_command_t cmd;
+  std::memcpy(&cmd, received.data(), sizeof(zenbedded_command_t));
+  EXPECT_FLOAT_EQ(cmd.motor_arm_position, 1.5f);
+
+  EXPECT_EQ(hw_->on_deactivate(state), CallbackReturn::SUCCESS);
+}
+
+TEST_F(TestZenbeddedHardware, multi_instance_independent_schemas)
+{
+  auto make_hw = [](
+                   const std::string & schema_file, const std::string & state_topic,
+                   const std::string & cmd_topic)
+  {
+    hardware_interface::HardwareInfo info;
+    info.name = schema_file;
+    info.hardware_parameters["zenoh_endpoint"] = "tcp/127.0.0.1:21555";
+    info.hardware_parameters["state_topic"] = state_topic;
+    info.hardware_parameters["command_topic"] = cmd_topic;
+    info.hardware_parameters["zenoh_mode"] = "client";
+    info.hardware_parameters["schema_path"] = std::string(TEST_CONFIG_DIR) + "/" + schema_file;
+
+    hardware_interface::HardwareComponentInterfaceParams params;
+    params.hardware_info = info;
+
+    auto hw = std::make_unique<zenbedded::ZenbeddedHardware>();
+    EXPECT_EQ(hw->on_init(params), CallbackReturn::SUCCESS);
+    return hw;
+  };
+
+  auto hw_arm = make_hw("instance_arm.yaml", "arm/state", "arm/cmd");
+  ASSERT_TRUE(hw_arm);
+  auto hw_gripper = make_hw("instance_gripper.yaml", "gripper/state", "gripper/cmd");
+  ASSERT_TRUE(hw_gripper);
+
+  // Verify each instance exports correct interfaces from its own schema
+  {
+    auto si = hw_arm->export_state_interfaces();
+    ASSERT_EQ(si.size(), 3);
+    EXPECT_EQ(si[0].get_name(), "shoulder/position");
+    EXPECT_EQ(si[1].get_name(), "shoulder/velocity");
+    EXPECT_EQ(si[2].get_name(), "elbow/position");
+
+    auto ci = hw_arm->export_command_interfaces();
+    ASSERT_EQ(ci.size(), 2);
+    EXPECT_EQ(ci[0].get_name(), "shoulder/position");
+    EXPECT_EQ(ci[1].get_name(), "elbow/position");
+  }
+  {
+    auto si = hw_gripper->export_state_interfaces();
+    ASSERT_EQ(si.size(), 1);
+    EXPECT_EQ(si[0].get_name(), "gripper/position");
+
+    auto ci = hw_gripper->export_command_interfaces();
+    ASSERT_EQ(ci.size(), 1);
+    EXPECT_EQ(ci[0].get_name(), "gripper/position");
+  }
+
+  // Activate both — each creates its own Zenoh session, sub, pub
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  ASSERT_EQ(hw_arm->on_activate(state), CallbackReturn::SUCCESS);
+  ASSERT_EQ(hw_gripper->on_activate(state), CallbackReturn::SUCCESS);
+
+  // Build state buffers: arm = 3×float32, gripper = 1×float32
+  std::vector<uint8_t> arm_state_buf(12);
+  float shoulder_pos = 1.0f, shoulder_vel = 2.0f, elbow_pos = 3.0f;
+  std::memcpy(arm_state_buf.data(), &shoulder_pos, 4);
+  std::memcpy(arm_state_buf.data() + 4, &shoulder_vel, 4);
+  std::memcpy(arm_state_buf.data() + 8, &elbow_pos, 4);
+
+  std::vector<uint8_t> gripper_state_buf(4);
+  float gripper_pos = 99.0f;
+  std::memcpy(gripper_state_buf.data(), &gripper_pos, 4);
+
+  // Publish on both topics, verify each reads only its own data
+  bool state_received = false;
+  for (int attempt = 0; attempt < 10; attempt++)
+  {
+    test_router_->put(zenoh::KeyExpr("arm/state"), arm_state_buf);
+    test_router_->put(zenoh::KeyExpr("gripper/state"), gripper_state_buf);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    hw_arm->read(rclcpp::Time(0), rclcpp::Duration(0, 0));
+    hw_gripper->read(rclcpp::Time(0), rclcpp::Duration(0, 0));
+
+    auto arm_si = hw_arm->export_state_interfaces();
+    auto gripper_si = hw_gripper->export_state_interfaces();
+    if (
+      arm_si.size() >= 3 && gripper_si.size() >= 1 &&
+      std::abs(static_cast<float>(arm_si[0].get_optional().value_or(0)) - 1.0f) < 0.001f &&
+      std::abs(static_cast<float>(gripper_si[0].get_optional().value_or(0)) - 99.0f) < 0.001f)
+    {
+      state_received = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(state_received);
+
+  auto arm_si = hw_arm->export_state_interfaces();
+  EXPECT_FLOAT_EQ(static_cast<float>(arm_si[0].get_optional().value()), 1.0f);
+  EXPECT_FLOAT_EQ(static_cast<float>(arm_si[1].get_optional().value()), 2.0f);
+  EXPECT_FLOAT_EQ(static_cast<float>(arm_si[2].get_optional().value()), 3.0f);
+
+  auto gripper_si = hw_gripper->export_state_interfaces();
+  EXPECT_FLOAT_EQ(static_cast<float>(gripper_si[0].get_optional().value()), 99.0f);
+
+  // Verify command isolation — subscribe on both topics
+  std::vector<uint8_t> arm_cmd_received, gripper_cmd_received;
+  auto arm_sub = test_router_->declare_subscriber(
+    zenoh::KeyExpr("arm/cmd"),
+    [&](zenoh::Sample & sample) { arm_cmd_received = sample.get_payload().as_vector(); }, []() {},
+    zenoh::Session::SubscriberOptions::create_default(), nullptr);
+  auto gripper_sub = test_router_->declare_subscriber(
+    zenoh::KeyExpr("gripper/cmd"),
+    [&](zenoh::Sample & sample) { gripper_cmd_received = sample.get_payload().as_vector(); },
+    []() {}, zenoh::Session::SubscriberOptions::create_default(), nullptr);
+
+  // Write on arm only — gripper subscriber must stay empty
+  auto arm_ci = hw_arm->export_command_interfaces();
+  ASSERT_GE(arm_ci.size(), 2);
+  ASSERT_TRUE(arm_ci[0].set_value(10.0));
+  ASSERT_TRUE(arm_ci[1].set_value(20.0));
+
+  bool cmd_published = false;
+  for (int attempt = 0; attempt < 5; attempt++)
+  {
+    hw_arm->write(rclcpp::Time(0), rclcpp::Duration(0, 0));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    if (!arm_cmd_received.empty())
+    {
+      cmd_published = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(cmd_published);
+  ASSERT_EQ(arm_cmd_received.size(), 8);  // 2 × float32
+  EXPECT_TRUE(gripper_cmd_received.empty())
+    << "Gripper received arm's command — topic isolation broken";
+
+  EXPECT_EQ(hw_arm->on_deactivate(state), CallbackReturn::SUCCESS);
+  EXPECT_EQ(hw_gripper->on_deactivate(state), CallbackReturn::SUCCESS);
 }


### PR DESCRIPTION
### Summary

All interface names and layouts come exclusively from a YAML file at runtime with no build-time dependency on generated structs. Implements lock-free `read()` and `write()` via `realtime_tools::RealtimeBuffer` and supports multiple independent hardware instances with different schemas in the same URDF.

### Changes

* **Lock-free read():** A Zenoh subscriber writes incoming state packets into a `RealtimeBuffer`. `read()` decodes fields from the buffer without any mutex.
* **Lock-free write():** `write()` encodes command values from `hw_commands_` into a pre-allocated buffer and publishes via Zenoh.
* **schema_path is mandatory:** Missing it in URDF params causes `on_init()` to return `ERROR`.
* **Generated header removed from hardware interface:** `#include "generated/interface_data.h"` and the associated `static_assert` have been removed from `zenbedded_hardware.hpp`. The hardware interface library has zero build-time dependency on generated structs. Change the schema YAML, restart the robot, and no rebuild is needed.
* **Multi-instance support:** Each `<ros2_control>` block in URDF gets its own `ZenbeddedHardware` instance with an independent schema, Zenoh session, state subscriber, and command publisher.

### Example URDF Configuration

```xml
<ros2_control name="Arm" type="system">
  <hardware>
    <plugin>zenbedded/ZenbeddedHardware</plugin>
    <param name="schema_path">$(find pkg)/config/arm.yaml</param>
    <param name="state_topic">arm/state</param>
    <param name="command_topic">arm/cmd</param>
  </hardware>
</ros2_control>

<ros2_control name="Gripper" type="system">
  <hardware>
    <plugin>zenbedded/ZenbeddedHardware</plugin>
    <param name="schema_path">$(find pkg)/config/gripper.yaml</param>
    <param name="state_topic">gripper/state</param>
    <param name="command_topic">gripper/cmd</param>
  </hardware>
</ros2_control>

```