### PR TITLE
fetch hal_espressif blob in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16
     && cd zephyr-sdk-0.16.8 \
     && ./setup.sh -t xtensa-espressif_esp32_zephyr-elf -t xtensa-espressif_esp32s3_zephyr-elf -t arm-zephyr-eabi -c -h
 
+RUN cd /zephyr_ws && west blobs fetch hal_espressif
 # Set environment variables
 ENV ZEPHYR_BASE=/zephyr_ws/zephyr
 ENV ZEPHYR_SDK_INSTALL_DIR=/zephyr_ws/zephyr-sdk-0.16.8


### PR DESCRIPTION
just a little change (twister tests for the demo requires the update)