### PR TITLE
Docker: Set Zephyr to version 4.4.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH=$(uname -m) && \
     && ./setup.sh -t xtensa-espressif_esp32_zephyr-elf -t xtensa-espressif_esp32s3_zephyr-elf -t arm-zephyr-eabi -c -h
 
 # Install all python dependencies for all subpackages
-RUN west packages pip --install --ignore-venv-check -- --break-system-packages
+RUN west packages pip --install --ignore-venv-check -- --break-system-packages --ignore-installed
 RUN west blobs fetch hal_espressif
 
 # apply patch containing macro redefinition warnings fix

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM ros:jazzy-ros-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG ZEPHYR_SDK_VERSION=1.0.1
+
 # Install system dependencies for both Zephyr and ROS 2
 RUN apt-get update && apt-get install -y \
     python3-pip python3-venv python3-setuptools \
@@ -29,16 +31,13 @@ RUN cd manifest-repo && git init -q && git add . \
     && git -c user.email=ci@local -c user.name=ci commit -qm "image manifest"
 RUN west init -l manifest-repo && west update && west zephyr-export
 
-# Copy python requirements from zephyr and install
-RUN pip3 install --ignore-installed --break-system-packages -r /zephyr_ws/zephyr/scripts/requirements.txt
-
 # Install Zephyr SDK(MINIMAL)
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then SDK_ARCH="aarch64"; else SDK_ARCH="x86_64"; fi && \
-    wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-${SDK_ARCH}_minimal.tar.xz \
-    && tar xf zephyr-sdk-0.16.8_linux-${SDK_ARCH}_minimal.tar.xz \
-    && rm zephyr-sdk-0.16.8_linux-${SDK_ARCH}_minimal.tar.xz \
-    && cd zephyr-sdk-0.16.8 \
+    wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-${SDK_ARCH}_minimal.tar.xz \
+    && tar xf zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-${SDK_ARCH}_minimal.tar.xz \
+    && rm zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-${SDK_ARCH}_minimal.tar.xz \
+    && cd zephyr-sdk-${ZEPHYR_SDK_VERSION} \
     && ./setup.sh -t xtensa-espressif_esp32_zephyr-elf -t xtensa-espressif_esp32s3_zephyr-elf -t arm-zephyr-eabi -c -h
 
 RUN cd /zephyr_ws

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,10 +40,9 @@ RUN ARCH=$(uname -m) && \
     && cd zephyr-sdk-${ZEPHYR_SDK_VERSION} \
     && ./setup.sh -t xtensa-espressif_esp32_zephyr-elf -t xtensa-espressif_esp32s3_zephyr-elf -t arm-zephyr-eabi -c -h
 
-RUN cd /zephyr_ws
-RUN west blobs fetch hal_espressif
-# install all python dependencies for all subpackages (not only zephyr)
+# Install all python dependencies for all subpackages
 RUN west packages pip --install --ignore-venv-check -- --break-system-packages
+RUN west blobs fetch hal_espressif
 
 # apply patch containing macro redefinition warnings fix
 WORKDIR /zephyr_ws/modules/lib/zenoh-pico

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN git apply wrap_zenoh_config.patch && rm wrap_zenoh_config.patch
 
 # Set environment variables
 ENV ZEPHYR_BASE=/zephyr_ws/zephyr
-ENV ZEPHYR_SDK_INSTALL_DIR=/zephyr_ws/zephyr-sdk-1.0.0
+ENV ZEPHYR_SDK_INSTALL_DIR=/zephyr_ws/zephyr-sdk-${ZEPHYR_SDK_VERSION}
 ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
 
 # Set up ROS 2 workspace structure

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     ccache dfu-util device-tree-compiler wget \
     python3-dev python3-tk python3-wheel xz-utils file \
     make gcc libsdl2-dev libmagic1 git \
+    libudev-dev libusb-1.0-0-dev pkg-config \
     ros-jazzy-ros2-control \
     ros-jazzy-ros2-controllers \
     ros-jazzy-rmw-zenoh-cpp \
@@ -40,7 +41,9 @@ RUN ARCH=$(uname -m) && \
     && cd zephyr-sdk-0.16.8 \
     && ./setup.sh -t xtensa-espressif_esp32_zephyr-elf -t xtensa-espressif_esp32s3_zephyr-elf -t arm-zephyr-eabi -c -h
 
-RUN cd /zephyr_ws && west blobs fetch hal_espressif
+RUN cd /zephyr_ws
+RUN west blobs fetch hal_espressif
+RUN west packages pip --install
 
 # apply patch containing macro redefinition warnings fix
 WORKDIR /zephyr_ws/modules/lib/zenoh-pico
@@ -49,7 +52,7 @@ RUN git apply wrap_zenoh_config.patch && rm wrap_zenoh_config.patch
 
 # Set environment variables
 ENV ZEPHYR_BASE=/zephyr_ws/zephyr
-ENV ZEPHYR_SDK_INSTALL_DIR=/zephyr_ws/zephyr-sdk-0.16.8
+ENV ZEPHYR_SDK_INSTALL_DIR=/zephyr_ws/zephyr-sdk-1.0.0
 ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
 
 # Set up ROS 2 workspace structure

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,8 @@ RUN ARCH=$(uname -m) && \
 
 RUN cd /zephyr_ws
 RUN west blobs fetch hal_espressif
-RUN west packages pip --install
+# install all python dependencies for all subpackages (not only zephyr)
+RUN west packages pip --install --ignore-venv-check -- --break-system-packages
 
 # apply patch containing macro redefinition warnings fix
 WORKDIR /zephyr_ws/modules/lib/zenoh-pico

--- a/docker/image-west.yml
+++ b/docker/image-west.yml
@@ -6,7 +6,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v3.7.0
+      revision: v4.4.2
       import: true
 
   self:


### PR DESCRIPTION
- Bumped zephyr version to 4.4.2 to allow us use the latest features
- Set the zephyr-sdk to 1.0.0
- Added new dependencies (libudev-dev libusb-1.0-0-dev) with west dependencies