### PR TITLE
Zenbedded transport api implementation

### DIFF
--- a/zenbedded_rcl/CMakeLists.txt
+++ b/zenbedded_rcl/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CONFIG_ZENBEDDED_RCL)
+if(DEFINED CONFIG_ZENBEDDED_RCL)
 
 if(NOT DEFINED ZENBEDDED_SCHEMA_FILE)
     set(ZENBEDDED_SCHEMA_FILE interface_schema.yaml)
@@ -21,7 +21,7 @@ find_package(zenbedded_schema REQUIRED NO_CMAKE_FIND_ROOT_PATH)
 
 
 # Generate the header at build time
-set(ZENBEDDED_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated_include/zenbedded_rcl/generated)
+set(ZENBEDDED_GEN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/zenbedded_rcl/generated)
 set(ZENBEDDED_GEN_HEADER ${ZENBEDDED_GEN_DIR}/interface_data.h)
 zenbedded_generate_header(
     YAML   ${ZENBEDDED_SCHEMA_FILE_ABS}
@@ -36,13 +36,9 @@ zephyr_library_sources(
         src/zenbedded_client.cpp
 )
 target_include_directories(zenbedded_rcl PUBLIC include)
-target_include_directories(zenbedded_rcl PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/generated_include)
 target_link_libraries(zenbedded_rcl PUBLIC zenbedded_transport)
 
 # Ensure the header exists before library compiles.
 add_dependencies(zenbedded_rcl ${generate_interface_data})
-if(TARGET app)
-    add_dependencies(app ${generate_interface_data})
-endif()
 
-endif() #CONFIG_ZENBEDDED_RCL
+endif() # CONFIG_ZENBEDDED_RCL

--- a/zenbedded_rcl/CMakeLists.txt
+++ b/zenbedded_rcl/CMakeLists.txt
@@ -35,12 +35,12 @@ zephyr_library_sources(
         src/hardware_component.cpp
         src/zenbedded_client.cpp
 )
-zephyr_library_include_directories(include)
-zephyr_library_link_libraries(zenbedded_transport)
-zephyr_include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated_include)
+target_include_directories(zenbedded_rcl PUBLIC include)
+target_include_directories(zenbedded_rcl PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/generated_include)
+target_link_libraries(zenbedded_rcl PUBLIC zenbedded_transport)
 
 # Ensure the header exists before library compiles.
-add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ${generate_interface_data})
+add_dependencies(zenbedded_rcl ${generate_interface_data})
 if(TARGET app)
     add_dependencies(app ${generate_interface_data})
 endif()

--- a/zenbedded_rcl/CMakeLists.txt
+++ b/zenbedded_rcl/CMakeLists.txt
@@ -30,12 +30,13 @@ zenbedded_generate_header(
 )
 
 
-zephyr_library()
+zephyr_library_named(zenbedded_rcl)
 zephyr_library_sources(
         src/hardware_component.cpp
         src/zenbedded_client.cpp
 )
 zephyr_library_include_directories(include)
+zephyr_library_link_libraries(zenbedded_transport)
 zephyr_include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated_include)
 
 # Ensure the header exists before library compiles.

--- a/zenbedded_rcl/CMakeLists.txt
+++ b/zenbedded_rcl/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(DEFINED CONFIG_ZENBEDDED_RCL)
+if(CONFIG_ZENBEDDED_RCL)
 
 if(NOT DEFINED ZENBEDDED_SCHEMA_FILE)
     set(ZENBEDDED_SCHEMA_FILE interface_schema.yaml)
@@ -21,7 +21,7 @@ find_package(zenbedded_schema REQUIRED NO_CMAKE_FIND_ROOT_PATH)
 
 
 # Generate the header at build time
-set(ZENBEDDED_GEN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/zenbedded_rcl/generated)
+set(ZENBEDDED_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated_include/zenbedded_rcl/generated)
 set(ZENBEDDED_GEN_HEADER ${ZENBEDDED_GEN_DIR}/interface_data.h)
 zenbedded_generate_header(
     YAML   ${ZENBEDDED_SCHEMA_FILE_ABS}
@@ -35,10 +35,15 @@ zephyr_library_sources(
         src/hardware_component.cpp
         src/zenbedded_client.cpp
 )
+
 target_include_directories(zenbedded_rcl PUBLIC include)
+target_include_directories(zenbedded_rcl PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/generated_include)
 target_link_libraries(zenbedded_rcl PUBLIC zenbedded_transport)
 
 # Ensure the header exists before library compiles.
 add_dependencies(zenbedded_rcl ${generate_interface_data})
+if(TARGET app)
+    add_dependencies(app ${generate_interface_data})
+endif()
 
 endif() # CONFIG_ZENBEDDED_RCL

--- a/zenbedded_rcl/include/zenbedded_rcl/codecs.hpp
+++ b/zenbedded_rcl/include/zenbedded_rcl/codecs.hpp
@@ -1,0 +1,186 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ZENBEDDED_RCL__CODECS_HPP_
+#define ZENBEDDED_RCL__CODECS_HPP_
+
+#include <zephyr/kernel.h>
+#include <cstddef>
+#include <cstring>
+#include <type_traits>
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+#include <zenbedded_transport/serialization.hpp>
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+
+// -------------------------------------------------------------------------------------------
+// The Codec concept
+// -------------------------------------------------------------------------------------------
+// ZenbeddedClient<StateCodec, CommandCodec> (zenbedded_client.hpp) never mentions a concrete
+// ROS 2 message type or a Tier by name. It only relies on this duck-typed contract, checked at
+// compile time when the template is instantiated:
+//
+//   Ctx           -- per-instance layout/offset state (e.g. precomputed CDR field offsets).
+//                    Opaque to the client; must be default-constructible.
+//   InitParams    -- whatever this message type needs at init time (topic-independent framing
+//                    like frame_id, joint_names, ...). Can be an empty struct.
+//   Value         -- the value passed to write() / populated by read().
+//
+//   static void init(Ctx &, const InitParams &, uint8_t * buf);
+//       Called once (per double-buffer slot) during ZenbeddedClient::init(). May write a
+//       persistent template into `buf` (e.g. Tier 1's CDR header/field names) that write()
+//       will patch on every call rather than rewrite from scratch -- see JointStateCodec.
+//   static size_t payload_size(const Ctx &);
+//       Wire size in bytes. Fixed after init() for the lifetime of the client.
+//
+// A codec used as a STATE (published/outgoing) channel additionally needs:
+//   static void write(const Ctx &, const Value &, uint8_t * buf);
+//
+// A codec used as a COMMAND (subscribed/incoming) channel additionally needs:
+//   static bool read(const Ctx &, const uint8_t * buf, size_t size, Value & out);
+//
+// A codec only needs to implement the direction(s) it's actually used for.
+// It Could have both read and write functions so its used for state/command codecs
+// -------------------------------------------------------------------------------------------
+
+// This class is an helper to check if a Codec is a valid Codec Type
+template <typename Codec>
+struct CheckCodec
+{
+  // clang-format off
+  template <typename C>
+  static auto check_state_codec(int) -> decltype(C::init(std::declval<typename C::Ctx &>(), std::declval<const typename C::InitParams &>(), static_cast<uint8_t *>(nullptr)), C::payload_size(std::declval<const typename C::Ctx &>()), C::write(std::declval<const typename C::Ctx &>(), std::declval<const typename C::Value &>(), static_cast<uint8_t *>(nullptr)), std::true_type{}); // NOLINT
+
+  template <typename C>
+  static auto check_command_codec(int) -> decltype(C::init(std::declval<typename C::Ctx &>(), std::declval<const typename C::InitParams &>(), static_cast<uint8_t *>(nullptr)), C::payload_size(std::declval<const typename C::Ctx &>()), C::read(std::declval<const typename C::Ctx &>(), static_cast<const uint8_t *>(nullptr), std::size_t{0}, std::declval<typename C::Value &>()), std::true_type{}); // NOLINT
+  // clang-format on
+
+  template <typename>
+  static std::false_type check_state_codec(...);
+
+  template <typename>
+  static std::false_type check_command_codec(...);
+
+  static constexpr bool is_valid_state_codec = decltype(check_state_codec<Codec>(0))::value;
+  static constexpr bool is_valid_command_codec = decltype(check_command_codec<Codec>(0))::value;
+};
+
+// Codec for any fixed-layout "just copy the bytes" type: a generic
+// passthrough codec for any trivially-copyable POD type T. No CDR framing, no per-instance
+// layout to compute -- InitParams is empty, payload_size is simply sizeof(T), and Ctx carries
+// nothing.
+template <typename T>
+struct RawCodec
+{
+  struct Ctx
+  {
+  };
+
+  struct InitParams
+  {
+  };
+
+  using Value = T;
+
+  static void init(Ctx &, const InitParams &, uint8_t *) {}
+
+  static size_t payload_size(const Ctx &) { return sizeof(T); }
+
+  static void write(const Ctx &, const Value & v, uint8_t * buf) { memcpy(buf, &v, sizeof(T)); }
+
+  static bool read(const Ctx &, const uint8_t * buf, size_t size, Value & out)
+  {
+    if (size < sizeof(T))
+    {
+      return false;
+    }
+    memcpy(&out, buf, sizeof(T));
+    return true;
+  }
+};
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+
+// Codec for sensor_msgs/msg/JointState
+struct JointStateCodec
+{
+  using Ctx = zcdr_joint_state_ctx_t;
+
+  struct InitParams
+  {
+    const char * frame_id;
+    const char ** joint_names;
+    uint32_t num_joints;
+  };
+
+  struct Value
+  {
+    int32_t stamp_sec;
+    uint32_t stamp_nanosec;
+    const double * positions;
+    const double * velocities;
+    const double * efforts;
+  };
+
+  static void init(Ctx & ctx, const InitParams & p, uint8_t * buf)
+  {
+    zcdr_init_joint_state(&ctx, p.frame_id, p.joint_names, p.num_joints, buf);
+  }
+
+  static size_t payload_size(const Ctx & ctx) { return ctx.payload_size; }
+
+  static void write(const Ctx & ctx, const Value & v, uint8_t * buf)
+  {
+    zcdr_serialize_joint_state(
+      &ctx, v.stamp_sec, v.stamp_nanosec, v.positions, v.velocities, v.efforts, buf);
+  }
+};
+
+// Codec for control_msgs/msg/JointCommand
+struct JointCommandCodec
+{
+  using Ctx = zcdr_joint_command_ctx_t;
+
+  struct InitParams
+  {
+    const char * frame_id;
+    const char ** joint_names;
+    uint32_t num_joints;
+    const char * interface_name;
+  };
+
+  struct Value
+  {
+    int32_t stamp_sec;
+    uint32_t stamp_nanosec;
+    double * values;
+  };
+
+  static void init(Ctx & ctx, const InitParams & p, uint8_t * buf)
+  {
+    zcdr_init_joint_command(&ctx, p.frame_id, p.joint_names, p.num_joints, p.interface_name, buf);
+  }
+
+  static size_t payload_size(const Ctx & ctx) { return ctx.payload_size; }
+
+  static bool read(const Ctx & ctx, const uint8_t * buf, size_t size, Value & out)
+  {
+    return zcdr_deserialize_joint_command(
+      &ctx, buf, size, &out.stamp_sec, &out.stamp_nanosec, out.values);
+  }
+};
+
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+
+#endif  // ZENBEDDED_RCL__CODECS_HPP_

--- a/zenbedded_rcl/include/zenbedded_rcl/zenbedded_client.hpp
+++ b/zenbedded_rcl/include/zenbedded_rcl/zenbedded_client.hpp
@@ -15,104 +15,152 @@
 #ifndef ZENBEDDED_RCL__ZENBEDDED_CLIENT_HPP_
 #define ZENBEDDED_RCL__ZENBEDDED_CLIENT_HPP_
 
-#include <zenoh-pico.h>
 #include <zephyr/kernel.h>
-#include "zenbedded_rcl/generated/interface_data.h"
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 
-class ZenbeddedClient
+#include "zenbedded_rcl/codecs.hpp"
+
+class ZenbeddedClientBase
 {
 public:
-  ZenbeddedClient() { reset_buffers(); }
+  ZenbeddedClientBase();
+  virtual ~ZenbeddedClientBase() = default;
 
-  /// @brief initialize the zenbedded client
-  /// @param control_freq the loop frequency in Hz (thread only start on positive values)
-  /// @return int
-  int init(const char * state_topic, const char * cmd_topic, uint32_t control_freq = 100);
-
-  // Deinitialize the client
+  /// @brief Deinitialize the client and underlying transport.
   void destroy();
 
-  // Synchronizes buffers between user and the zenbedded client.
-  void sync();
-
-  // Publish the current state via Zenoh.
+  /// @brief Publish current state buffer over Zenoh transport.
   int zenoh_publish_state();
 
-  /// @brief start the zenbedded thread
-  /// @param control_freq the loop frequency in Hz (thread only start on positive values)
-  /// @return int
+  /// @brief Start the control publish thread.
   int start_thread(uint32_t control_freq);
 
-  // Stop zenbedded thread
+  /// @brief Stop the control publish thread.
   void stop_thread();
 
-  // Get a reference to the user's state buffer (for writing).
-  zenbedded_state_t & state() { return user_state_buffer_; }
-
-  // Get a const reference to the user's command buffer (for reading).
-  [[nodiscard]] const zenbedded_command_t & command() const { return user_command_buffer_; }
-
-  // Check if client is initialized.
+  /// @brief Check if client is initialized.
   [[nodiscard]] bool is_initialized() const { return initialized_; }
 
-  bool is_control_thread_running() { return atomic_get(&control_thread_running_); }
+  /// @brief Check if publish thread is running.
+  bool is_control_thread_running();
+
+protected:
+  /// @brief Initializes base buffers, transport layer, and background thread.
+  int init_base(uint32_t control_freq, size_t state_payload_size, size_t cmd_payload_size);
+
+  /// @brief Direct slot access for state codec template initialization.
+  uint8_t * get_state_buffer_slot(size_t slot_idx);
+
+  /// @brief Acquire inactive state buffer index for thread-safe writing.
+  uint8_t * prepare_state_write_slot(int & out_write_idx);
+
+  /// @brief Commit atomic state buffer write and flip active index.
+  void commit_state_write_slot(int write_idx);
+
+  /// @brief Read raw latest command bytes from double buffer.
+  bool read_latest_command_raw(uint8_t * data, size_t size);
+
+  /// @brief Reset atomic buffer states and versions.
+  void reset_buffers();
+
+  bool initialized_ = false;
+  size_t state_payload_size_ = 0;
+  size_t cmd_payload_size_ = 0;
 
 private:
-  // Double-buffer for State
-  zenbedded_state_t state_buffer_[2];  // Double buffer for states
-  atomic_t state_buffer_active_idx_;   // Which buffer is active (0 or 1)
-  atomic_t state_buffer_version_[2];   // buffer versioning for ABA prevention
+  uint8_t state_buffer_[2][CONFIG_ZENBEDDED_MAX_STATE_BUFFER_SIZE]{};
+  atomic_t state_buffer_active_idx_{};
+  atomic_t state_buffer_version_[2]{};
 
-  // Double-buffer for Command
-  zenbedded_command_t cmd_buffer_[2];  // Double buffer for commands
-  atomic_t cmd_buffer_active_idx_;     // Which buffer is active (0 or 1)
-  atomic_t cmd_buffer_version_[2];     // buffer versioning for ABA prevention
+  uint8_t cmd_buffer_[2][CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE]{};
+  atomic_t cmd_buffer_active_idx_{};
+  atomic_t cmd_buffer_version_[2]{};
 
-  // User-space buffers (accessed by user thread)
-  zenbedded_state_t user_state_buffer_{};      // User writes state here
-  zenbedded_command_t user_command_buffer_{};  // User reads commands here
-
-  // Zenoh session, pub & sub.
-  z_owned_session_t z_session_{};
-  z_owned_publisher_t z_state_pub_{};
-  z_owned_subscriber_t z_cmd_sub_{};
-
-  // zenoh topics
-  const char * state_topic_ = nullptr;
-  const char * cmd_topic_ = nullptr;
-
-  // module ready
-  bool initialized_ = false;
-
-  // control thread variables
   uint32_t control_freq_ = 0;
   atomic_t control_thread_running_ = 0;
   bool control_thread_started_ = false;
-  k_thread control_thread_;
-  K_KERNEL_STACK_MEMBER(control_thread_stack_, CONFIG_ZENBEDDED_RCL_THREAD_STACK_SIZE);
+  k_thread control_thread_{};
+  K_KERNEL_STACK_MEMBER(control_thread_stack_, CONFIG_ZENBEDDED_RCL_THREAD_STACK_SIZE) {};
 
-  // Control thread function
   static void control_thread_fn(void * arg1, void * arg2, void * arg3);
+  static void on_transport_cmd_cb(const uint8_t * payload, size_t size, void * user_data);
 
-  // Control flags
-  // reset buffers and locks
-  void reset_buffers();
+  void write_state_to_buffer(const uint8_t * data, size_t size);
+  bool read_state_from_buffer(uint8_t * data, size_t size);
+  void write_command_to_buffer(const uint8_t * data, size_t size);
+  bool read_command_from_buffer(uint8_t * data, size_t size);
+};
 
-  // The Zenoh subscriber callback.
-  static void on_zenoh_command_cb(z_loaned_sample_t * sample, void * arg);
+template <typename StateCodec, typename CommandCodec>
+class ZenbeddedClient : public ZenbeddedClientBase
+{
+public:
+  using StateInitParams = typename StateCodec::InitParams;
+  using CommandInitParams = typename CommandCodec::InitParams;
+  using StateValue = typename StateCodec::Value;
+  using CommandValue = typename CommandCodec::Value;
 
-  // buffer read/write commands
-  void write_state_to_buffer(const zenbedded_state_t & state);
+  ZenbeddedClient()
+  {
+    static_assert(CheckCodec<StateCodec>::is_valid_state_codec, "Invalid StateCodec Type!");
+    static_assert(CheckCodec<CommandCodec>::is_valid_command_codec, "Invalid CommandCodec Type!");
+  }
 
-  bool read_state_from_buffer(zenbedded_state_t & state);
+  int init(
+    uint32_t control_freq, const StateInitParams & state_params = {},
+    const CommandInitParams & cmd_params = {})
+  {
+    if (initialized_)
+    {
+      return 0;
+    }
 
-  void write_command_to_buffer(const zenbedded_command_t & cmd);
+    reset_buffers();
 
-  bool read_command_from_buffer(zenbedded_command_t & cmd);
+    // Initialize state headers/codecs directly in double-buffer slots
+    StateCodec::init(state_ctx_, state_params, get_state_buffer_slot(0));
+    StateCodec::init(state_ctx_, state_params, get_state_buffer_slot(1));
+    size_t st_size = StateCodec::payload_size(state_ctx_);
 
-  void start_zenoh_task();
+    // Determine command payload size using scratchpad space
+    uint8_t cmd_layout_scratch[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
+    CommandCodec::init(cmd_ctx_, cmd_params, cmd_layout_scratch);
+    size_t cmd_size = CommandCodec::payload_size(cmd_ctx_);
 
-  void stop_zenoh_task();
+    return init_base(control_freq, st_size, cmd_size);
+  }
+
+  void write_state(const StateValue & value)
+  {
+    if (!initialized_)
+    {
+      return;
+    }
+    int write_idx = 0;
+    uint8_t * buf = prepare_state_write_slot(write_idx);
+    StateCodec::write(state_ctx_, value, buf);
+    commit_state_write_slot(write_idx);
+  }
+
+  bool read_command(CommandValue & out)
+  {
+    if (!initialized_)
+    {
+      return false;
+    }
+    uint8_t tmp[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
+    if (!read_latest_command_raw(tmp, cmd_payload_size_))
+    {
+      return false;
+    }
+    return CommandCodec::read(cmd_ctx_, tmp, cmd_payload_size_, out);
+  }
+
+private:
+  typename StateCodec::Ctx state_ctx_{};
+  typename CommandCodec::Ctx cmd_ctx_{};
 };
 
 #endif  // ZENBEDDED_RCL__ZENBEDDED_CLIENT_HPP_

--- a/zenbedded_rcl/src/zenbedded_client.cpp
+++ b/zenbedded_rcl/src/zenbedded_client.cpp
@@ -209,7 +209,7 @@ void ZenbeddedClientBase::control_thread_fn(void * arg1, void * arg2, void * arg
     return;
   }
 
-  LOG_INF("Control thread started at %d", self->control_freq_);
+  LOG_INF("Control thread started");
 
   const uint32_t period_ms = MAX(1000 / self->control_freq_, 1);
   uint32_t prev_time = k_uptime_get_32();

--- a/zenbedded_rcl/src/zenbedded_client.cpp
+++ b/zenbedded_rcl/src/zenbedded_client.cpp
@@ -209,7 +209,7 @@ void ZenbeddedClientBase::control_thread_fn(void * arg1, void * arg2, void * arg
     return;
   }
 
-  LOG_INF("Control thread started at %.2f", self->control_freq_);
+  LOG_INF("Control thread started at %d", self->control_freq_);
 
   const uint32_t period_ms = MAX(1000 / self->control_freq_, 1);
   uint32_t prev_time = k_uptime_get_32();

--- a/zenbedded_rcl/src/zenbedded_client.cpp
+++ b/zenbedded_rcl/src/zenbedded_client.cpp
@@ -13,34 +13,16 @@
 // limitations under the License.
 
 #include "zenbedded_rcl/zenbedded_client.hpp"
-#include <zenoh-pico.h>
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <cerrno>
+#include <zenbedded_transport/zenoh_transport.hpp>
 
 LOG_MODULE_REGISTER(zenbedded_client, LOG_LEVEL_INF);
 
-// Static pointer to the client instance for the callback
-static ZenbeddedClient * zrcl_instance = nullptr;
+ZenbeddedClientBase::ZenbeddedClientBase() { reset_buffers(); }
 
-void ZenbeddedClient::reset_buffers()
-{
-  // reset atomic variables
-  atomic_set(&state_buffer_active_idx_, 0);
-  atomic_set(&cmd_buffer_active_idx_, 0);
-
-  atomic_set(&state_buffer_version_[0], 0);
-  atomic_set(&state_buffer_version_[1], 0);
-  atomic_set(&cmd_buffer_version_[0], 0);
-  atomic_set(&cmd_buffer_version_[1], 0);
-
-  // Clear buffers
-  memset(state_buffer_, 0, sizeof(state_buffer_));
-  memset(cmd_buffer_, 0, sizeof(cmd_buffer_));
-  memset(&user_state_buffer_, 0, sizeof(user_state_buffer_));
-  memset(&user_command_buffer_, 0, sizeof(user_command_buffer_));
-}
-
-int ZenbeddedClient::init(const char * state_topic, const char * cmd_topic, uint32_t control_freq)
+int ZenbeddedClientBase::init_base(
+  uint32_t control_freq, size_t state_payload_size, size_t cmd_payload_size)
 {
   if (initialized_)
   {
@@ -48,212 +30,69 @@ int ZenbeddedClient::init(const char * state_topic, const char * cmd_topic, uint
     return 0;
   }
 
-  if (!state_topic || !cmd_topic)
+  state_payload_size_ = state_payload_size;
+  if (state_payload_size_ > CONFIG_ZENBEDDED_MAX_STATE_BUFFER_SIZE)
   {
-    LOG_ERR("State and command topics cannot be NULL");
-    return -EINVAL;
+    LOG_ERR(
+      "State payload (%zu) exceeds CONFIG_ZENBEDDED_MAX_STATE_BUFFER_SIZE (%d)",
+      state_payload_size_, CONFIG_ZENBEDDED_MAX_STATE_BUFFER_SIZE);
+    return -ENOMEM;
   }
 
-  state_topic_ = state_topic;
-  cmd_topic_ = cmd_topic;
-
-  reset_buffers();
-
-  // Zenoh Config
-  z_owned_config_t config;
-  z_config_default(&config);
-  zp_config_insert(z_config_loan_mut(&config), Z_CONFIG_MODE_KEY, CONFIG_ZENBEDDED_RCL_ZENOH_MODE);
-
-  if (strcmp(CONFIG_ZENBEDDED_RCL_ZENOH_LOCATOR, "") != 0)
+  cmd_payload_size_ = cmd_payload_size;
+  if (cmd_payload_size_ > CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE)
   {
-    zp_config_insert(
-      z_loan_mut(config),
-      (strcmp(CONFIG_ZENBEDDED_RCL_ZENOH_MODE, "client") == 0) ? Z_CONFIG_CONNECT_KEY
-                                                               : Z_CONFIG_LISTEN_KEY,
-      CONFIG_ZENBEDDED_RCL_ZENOH_LOCATOR);
+    LOG_ERR(
+      "Command payload (%zu) exceeds CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE (%d)", cmd_payload_size_,
+      CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE);
+    return -ENOMEM;
   }
 
-  z_result_t ret = z_open(&z_session_, z_move(config), nullptr);
-  if (ret < 0)
-  {
-    LOG_ERR("Failed to open Zenoh session");
-    return ret;
-  }
+  zenbedded_set_subscriber_cb(&ZenbeddedClientBase::on_transport_cmd_cb, this);
 
-  LOG_INF("opened session");
-  start_zenoh_task();
-
-  // Declare publisher for state (using configured topic)
-  z_view_keyexpr_t ke_state;
-  if (z_view_keyexpr_from_str(&ke_state, state_topic) < 0)
+  if (zenbedded_transport_init() != 0)
   {
-    LOG_ERR("Invalid state topic: %s", state_topic);
-    stop_zenoh_task();
-    z_close(z_session_loan_mut(&z_session_), nullptr);
-    return -EINVAL;
-  }
-  if (
-    z_declare_publisher(z_session_loan(&z_session_), &z_state_pub_, z_loan(ke_state), nullptr) < 0)
-  {
-    LOG_ERR("Failed to declare state publisher on topic: %s", state_topic);
-    stop_zenoh_task();
-    z_close(z_session_loan_mut(&z_session_), nullptr);
-    return -EIO;
-  }
-
-  // subscriber for commands (using configured topic)
-  z_owned_closure_sample_t callback;
-  z_closure(&callback, on_zenoh_command_cb, nullptr, this);
-  z_view_keyexpr_t ke_cmd;
-  if (z_view_keyexpr_from_str(&ke_cmd, cmd_topic) < 0)
-  {
-    LOG_ERR("Invalid command topic: %s", cmd_topic);
-    z_undeclare_publisher(z_publisher_move(&z_state_pub_));
-    stop_zenoh_task();
-    z_close(z_session_loan_mut(&z_session_), nullptr);
-    return -EINVAL;
-  }
-  if (
-    z_declare_subscriber(
-      z_session_loan(&z_session_), &z_cmd_sub_, z_loan(ke_cmd), z_move(callback), nullptr) < 0)
-  {
-    LOG_ERR("Failed to declare command subscriber on topic: %s", cmd_topic);
-    z_undeclare_publisher(z_publisher_move(&z_state_pub_));
-    stop_zenoh_task();
-    z_close(z_session_loan_mut(&z_session_), nullptr);
+    LOG_ERR("Failed to initialize zenbedded transport");
     return -EIO;
   }
 
   initialized_ = true;
   control_freq_ = control_freq;
-  zrcl_instance = this;
 
-  LOG_INF("ZenbeddedClient initialized: state='%s', cmd='%s'", state_topic, cmd_topic);
-  start_thread(control_freq);
-  return 0;
+  LOG_INF(
+    "ZenbeddedClient initialized (state_size=%zuB, cmd_size=%zuB)", state_payload_size_,
+    cmd_payload_size_);
+
+  return start_thread(control_freq);
 }
 
-void ZenbeddedClient::destroy()
+void ZenbeddedClientBase::destroy()
 {
   if (!initialized_)
   {
     return;
   }
   stop_thread();
-  z_undeclare_subscriber(z_subscriber_move(&z_cmd_sub_));
-  z_undeclare_publisher(z_publisher_move(&z_state_pub_));
-  z_close(z_session_loan_mut(&z_session_), nullptr);
-
-  z_session_drop(z_session_move(&z_session_));
+  zenbedded_transport_close();
+  zenbedded_set_subscriber_cb(nullptr, nullptr);
 
   initialized_ = false;
-  zrcl_instance = nullptr;
-
   LOG_INF("ZenbeddedClient deinitialized");
 }
 
-void ZenbeddedClient::on_zenoh_command_cb(z_loaned_sample_t * sample, void * arg)
+uint8_t * ZenbeddedClientBase::get_state_buffer_slot(size_t slot_idx)
 {
-  zenbedded_command_t cmd;
-  z_bytes_reader_t reader = z_bytes_get_reader(z_sample_payload(sample));
-  size_t bytes_copied =
-    z_bytes_reader_read(&reader, reinterpret_cast<uint8_t *>(&cmd), sizeof(zenbedded_command_t));
-
-  if (bytes_copied != sizeof(zenbedded_command_t))
-  {
-    LOG_WRN("Invalid command size: %zu, expected %zu", bytes_copied, sizeof(zenbedded_command_t));
-    return;
-  }
-
-  auto * self = static_cast<ZenbeddedClient *>(arg);
-  self->write_command_to_buffer(cmd);
+  return state_buffer_[slot_idx];
 }
 
-int ZenbeddedClient::zenoh_publish_state()
+uint8_t * ZenbeddedClientBase::prepare_state_write_slot(int & out_write_idx)
 {
-  if (!initialized_)
-  {
-    LOG_ERR("Zenbedded Client not initialized");
-    return -ENODEV;
-  }
-
-  // used slices to ensure zero dynamic allocations
-  zenbedded_state_t state;
-  z_owned_bytes_t payload;
-  z_owned_slice_t slice;
-
-  while (!read_state_from_buffer(state))
-  {
-  }
-
-  z_slice_from_buf(
-    &slice, reinterpret_cast<uint8_t *>(&state), sizeof(zenbedded_state_t), nullptr, nullptr);
-  z_bytes_from_slice(&payload, z_move(slice));
-
-  z_result_t ret = z_publisher_put(z_loan(z_state_pub_), z_move(payload), nullptr);
-  if (ret < 0)
-  {
-    LOG_ERR("Failed to publish state: %d", ret);
-  }
-  return ret;
+  out_write_idx = atomic_get(&state_buffer_active_idx_) ^ 1;
+  return state_buffer_[out_write_idx];
 }
 
-void ZenbeddedClient::sync()
+void ZenbeddedClientBase::commit_state_write_slot(int write_idx)
 {
-  if (!initialized_)
-  {
-    LOG_ERR("Zenbedded Client not initialized");
-    return;
-  }
-
-  write_state_to_buffer(user_state_buffer_);
-  while (!read_command_from_buffer(user_command_buffer_))
-  {
-  }
-}
-
-bool ZenbeddedClient::read_state_from_buffer(zenbedded_state_t & state)
-{
-  const int read_idx = atomic_get(&state_buffer_active_idx_);
-  const atomic_val_t ver_before = atomic_get(&state_buffer_version_[read_idx]);
-  state = state_buffer_[read_idx];
-
-  // Ensure read completes before consistency check
-  __atomic_thread_fence(__ATOMIC_ACQUIRE);
-
-  // Verify consistency
-  if (
-    atomic_get(&state_buffer_active_idx_) != read_idx ||
-    atomic_get(&state_buffer_version_[read_idx]) != ver_before)
-  {
-    return false;
-  }
-  return true;
-}
-
-bool ZenbeddedClient::read_command_from_buffer(zenbedded_command_t & cmd)
-{
-  const int read_idx = atomic_get(&cmd_buffer_active_idx_);
-  const atomic_val_t ver_before = atomic_get(&cmd_buffer_version_[read_idx]);
-  cmd = cmd_buffer_[read_idx];
-
-  // Ensure read completes before consistency check
-  __atomic_thread_fence(__ATOMIC_ACQUIRE);
-
-  if (
-    atomic_get(&cmd_buffer_active_idx_) != read_idx ||
-    atomic_get(&cmd_buffer_version_[read_idx]) != ver_before)
-  {
-    return false;
-  }
-  return true;
-}
-
-void ZenbeddedClient::write_state_to_buffer(const zenbedded_state_t & state)
-{
-  const int write_idx = atomic_get(&state_buffer_active_idx_) ^ 1;
-  state_buffer_[write_idx] = state;
-
   // Ensure write completes before version increment
   __atomic_thread_fence(__ATOMIC_RELEASE);
 
@@ -261,19 +100,36 @@ void ZenbeddedClient::write_state_to_buffer(const zenbedded_state_t & state)
   atomic_set(&state_buffer_active_idx_, write_idx);  // Flip active index
 }
 
-void ZenbeddedClient::write_command_to_buffer(const zenbedded_command_t & cmd)
+bool ZenbeddedClientBase::read_latest_command_raw(uint8_t * data, size_t size)
 {
-  const int write_idx = atomic_get(&cmd_buffer_active_idx_) ^ 1;
-  cmd_buffer_[write_idx] = cmd;
-
-  // Ensure write completes before version increment
-  __atomic_thread_fence(__ATOMIC_RELEASE);
-
-  atomic_inc(&cmd_buffer_version_[write_idx]);
-  atomic_set(&cmd_buffer_active_idx_, write_idx);  // Flip active index
+  while (!read_command_from_buffer(data, size))
+  {
+  }
+  return true;
 }
 
-int ZenbeddedClient::start_thread(uint32_t control_freq)
+int ZenbeddedClientBase::zenoh_publish_state()
+{
+  if (!initialized_)
+  {
+    LOG_ERR("Zenbedded Client not initialized");
+    return -ENODEV;
+  }
+
+  uint8_t tmp[CONFIG_ZENBEDDED_MAX_STATE_BUFFER_SIZE];
+  while (!read_state_from_buffer(tmp, state_payload_size_))
+  {
+  }
+
+  int ret = zenbedded_publish(tmp, state_payload_size_);
+  if (ret < 0)
+  {
+    LOG_ERR("Failed to publish state: %d", ret);
+  }
+  return ret;
+}
+
+int ZenbeddedClientBase::start_thread(uint32_t control_freq)
 {
   if (!initialized_)
   {
@@ -283,7 +139,7 @@ int ZenbeddedClient::start_thread(uint32_t control_freq)
 
   if (control_freq == 0)
   {
-    LOG_WRN("Control Thread frequency is zero, thread unable to start");
+    LOG_WRN("Control Thread frequency is zero, thread wouldn't be started");
     return -EINVAL;
   }
 
@@ -299,7 +155,7 @@ int ZenbeddedClient::start_thread(uint32_t control_freq)
   k_thread_create(
     &control_thread_, control_thread_stack_, K_KERNEL_STACK_SIZEOF(control_thread_stack_),
     control_thread_fn,
-    this,     // arg1 - pass client instance
+    this,     // arg1
     nullptr,  // arg2
     nullptr,  // arg3
     CONFIG_ZENBEDDED_RCL_THREAD_PRIORITY,
@@ -308,12 +164,11 @@ int ZenbeddedClient::start_thread(uint32_t control_freq)
   );
 
   control_thread_started_ = true;
-
-  LOG_INF("Started thread at %i Hz", control_freq);
+  LOG_INF("Started thread at %u Hz", control_freq);
   return 0;
 }
 
-void ZenbeddedClient::stop_thread()
+void ZenbeddedClientBase::stop_thread()
 {
   if (!control_thread_started_)
   {
@@ -323,7 +178,6 @@ void ZenbeddedClient::stop_thread()
   LOG_INF("Stopping control thread");
   atomic_set(&control_thread_running_, 0);  // cleanly exit thread loop
 
-  // Wait for thread to exit (with timeout)
   int timeout_ms = 200;
   while (atomic_get(&control_thread_running_) != 0 && timeout_ms > 0)
   {
@@ -339,16 +193,15 @@ void ZenbeddedClient::stop_thread()
 
   control_thread_started_ = false;
   control_freq_ = 0;
-
   LOG_INF("Publish thread stopped");
 }
 
-void ZenbeddedClient::control_thread_fn(void * arg1, void * arg2, void * arg3)
+void ZenbeddedClientBase::control_thread_fn(void * arg1, void * arg2, void * arg3)
 {
   ARG_UNUSED(arg2);
   ARG_UNUSED(arg3);
 
-  auto * self = static_cast<ZenbeddedClient *>(arg1);
+  auto * self = static_cast<ZenbeddedClientBase *>(arg1);
 
   if (!self)
   {
@@ -356,7 +209,7 @@ void ZenbeddedClient::control_thread_fn(void * arg1, void * arg2, void * arg3)
     return;
   }
 
-  LOG_INF("Control thread started");
+  LOG_INF("Control thread started at %.2f", self->control_freq_);
 
   const uint32_t period_ms = MAX(1000 / self->control_freq_, 1);
   uint32_t prev_time = k_uptime_get_32();
@@ -370,25 +223,100 @@ void ZenbeddedClient::control_thread_fn(void * arg1, void * arg2, void * arg3)
     }
 
     const uint32_t diff = k_uptime_get_32() - prev_time;
-    const uint32_t sleep_ms =
-      (diff >= period_ms) ? 1 : (period_ms - diff);  // make sure we don't overflow
-    k_sleep(K_MSEC(sleep_ms));                       // wait for extra time to maintain loop freq
+    const uint32_t sleep_ms = (diff >= period_ms) ? 1 : (period_ms - diff);
+    k_sleep(K_MSEC(sleep_ms));
     prev_time = k_uptime_get_32();
   }
 
-  // Clear running flag to signal exit
   atomic_set(&self->control_thread_running_, 0);
   LOG_INF("Publish thread stopped");
 }
 
-void ZenbeddedClient::start_zenoh_task()
+bool ZenbeddedClientBase::is_control_thread_running()
 {
-  zp_start_read_task(z_session_loan_mut(&z_session_), nullptr);
-  zp_start_lease_task(z_session_loan_mut(&z_session_), nullptr);
+  return atomic_get(&control_thread_running_);
 }
 
-void ZenbeddedClient::stop_zenoh_task()
+void ZenbeddedClientBase::reset_buffers()
 {
-  zp_stop_lease_task(z_session_loan_mut(&z_session_));
-  zp_stop_read_task(z_session_loan_mut(&z_session_));
+  atomic_set(&state_buffer_active_idx_, 0);
+  atomic_set(&cmd_buffer_active_idx_, 0);
+
+  atomic_set(&state_buffer_version_[0], 0);
+  atomic_set(&state_buffer_version_[1], 0);
+  atomic_set(&cmd_buffer_version_[0], 0);
+  atomic_set(&cmd_buffer_version_[1], 0);
+
+  memset(state_buffer_, 0, sizeof(state_buffer_));
+  memset(cmd_buffer_, 0, sizeof(cmd_buffer_));
+}
+
+void ZenbeddedClientBase::on_transport_cmd_cb(
+  const uint8_t * payload, size_t size, void * user_data)
+{
+  auto * self = static_cast<ZenbeddedClientBase *>(user_data);
+
+  if (size != self->cmd_payload_size_)
+  {
+    LOG_WRN("Unexpected command payload size: %zu, expected %zu", size, self->cmd_payload_size_);
+    return;
+  }
+
+  self->write_command_to_buffer(payload, size);
+}
+
+bool ZenbeddedClientBase::read_state_from_buffer(uint8_t * data, size_t size)
+{
+  const int read_idx = atomic_get(&state_buffer_active_idx_);
+  const atomic_val_t ver_before = atomic_get(&state_buffer_version_[read_idx]);
+  memcpy(data, state_buffer_[read_idx], size);
+
+  __atomic_thread_fence(__ATOMIC_ACQUIRE);
+
+  if (
+    atomic_get(&state_buffer_active_idx_) != read_idx ||
+    atomic_get(&state_buffer_version_[read_idx]) != ver_before)
+  {
+    return false;
+  }
+  return true;
+}
+
+void ZenbeddedClientBase::write_state_to_buffer(const uint8_t * data, size_t size)
+{
+  const int write_idx = atomic_get(&state_buffer_active_idx_) ^ 1;
+  memcpy(state_buffer_[write_idx], data, size);
+
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+
+  atomic_inc(&state_buffer_version_[write_idx]);
+  atomic_set(&state_buffer_active_idx_, write_idx);
+}
+
+void ZenbeddedClientBase::write_command_to_buffer(const uint8_t * data, size_t size)
+{
+  const int write_idx = atomic_get(&cmd_buffer_active_idx_) ^ 1;
+  memcpy(cmd_buffer_[write_idx], data, size);
+
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+
+  atomic_inc(&cmd_buffer_version_[write_idx]);
+  atomic_set(&cmd_buffer_active_idx_, write_idx);
+}
+
+bool ZenbeddedClientBase::read_command_from_buffer(uint8_t * data, size_t size)
+{
+  const int read_idx = atomic_get(&cmd_buffer_active_idx_);
+  const atomic_val_t ver_before = atomic_get(&cmd_buffer_version_[read_idx]);
+  memcpy(data, cmd_buffer_[read_idx], size);
+
+  __atomic_thread_fence(__ATOMIC_ACQUIRE);
+
+  if (
+    atomic_get(&cmd_buffer_active_idx_) != read_idx ||
+    atomic_get(&cmd_buffer_version_[read_idx]) != ver_before)
+  {
+    return false;
+  }
+  return true;
 }

--- a/zenbedded_transport/CMakeLists.txt
+++ b/zenbedded_transport/CMakeLists.txt
@@ -7,4 +7,4 @@ zephyr_library_sources(
   src/serialization.cpp
 )
 
-zephyr_library_include_directories(include)
+target_include_directories(zenbedded_transport PUBLIC include)

--- a/zenbedded_transport/CMakeLists.txt
+++ b/zenbedded_transport/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.20.0)
 
-zephyr_library()
+zephyr_library_named(zenbedded_transport)
 
 zephyr_library_sources(
   src/zenoh_transport.cpp
   src/serialization.cpp
 )
 
-zephyr_include_directories(include)
+zephyr_library_include_directories(include)

--- a/zenbedded_transport/Kconfig
+++ b/zenbedded_transport/Kconfig
@@ -1,13 +1,5 @@
 menu "Zephyr Zenoh Integration Configuration"
 
-    config ZENBEDDED_ROS2_DOMAIN_ID
-        int "ROS 2 Domain ID"
-        default 0
-
-    config ZENBEDDED_ROS2_NODE_NAME
-        string "The ros2 node name assigned to the MCU if TIER_1 is enabled"
-        default "zenbedded_mcu"
-
     config ZENBEDDED_ZENOH_MODE
         string "The mode for zenoh-pico peer/client"
         default "client"
@@ -44,5 +36,54 @@ menu "Zephyr Zenoh Integration Configuration"
     config ZENBEDDED_MAX_CMD_BUFFER_SIZE
         int "Maximum size of cmd message (for static allocation)"
         default 256
+
+
+    if ZENBEDDED_TRANSPORT_TIER_1
+
+    config ZENBEDDED_DOMAIN_ID
+        int "ROS 2 Domain ID"
+        default 0
+
+    config ZENBEDDED_NODE_NAME
+        string "The ros2 node name assigned to the MCU"
+        default "zenbedded_mcu"
+
+    choice
+        prompt "State (published) message type"
+        default ZENBEDDED_STATE_MSG_JOINT_STATE
+        help
+          ROS 2 message type serialized onto ZENBEDDED_PUB_TOPIC.
+
+        config ZENBEDDED_STATE_MSG_IMU
+            bool "sensor_msgs/msg/Imu"
+
+        config ZENBEDDED_STATE_MSG_JOINT_STATE
+            bool "sensor_msgs/msg/JointState"
+
+        config ZENBEDDED_STATE_MSG_FLOAT64_MULTI_ARRAY
+            bool "std_msgs/msg/Float64MultiArray"
+
+        config ZENBEDDED_STATE_MSG_TWIST
+            bool "geometry_msgs/msg/Twist"
+    endchoice
+
+    choice
+        prompt "Command (subscribed) message type"
+        default ZENBEDDED_CMD_MSG_JOINT_COMMAND
+        help
+          ROS 2 message type deserialized from ZENBEDDED_SUB_TOPIC.
+
+        config ZENBEDDED_CMD_MSG_JOINT_COMMAND
+            bool "control_msgs/msg/JointCommand"
+
+        config ZENBEDDED_CMD_MSG_FLOAT64_MULTI_ARRAY
+            bool "std_msgs/msg/Float64MultiArray"
+
+        config ZENBEDDED_CMD_MSG_TWIST
+            bool "geometry_msgs/msg/Twist"
+    endchoice
+
+    endif # ZENBEDDED_TRANSPORT_TIER_1
+
 
 endmenu

--- a/zenbedded_transport/Kconfig
+++ b/zenbedded_transport/Kconfig
@@ -1,19 +1,48 @@
 menu "Zephyr Zenoh Integration Configuration"
 
-config ZENOH_TRANSPORT_DOMAIN_ID
-    int "ROS 2 Domain ID"
-    default 0
+    config ZENBEDDED_ROS2_DOMAIN_ID
+        int "ROS 2 Domain ID"
+        default 0
 
-choice ZENOH_TRANSPORT_TIER
-    prompt "Integration Tier"
-    default TIER_1
+    config ZENBEDDED_ROS2_NODE_NAME
+        string "The ros2 node name assigned to the MCU if TIER_1 is enabled"
+        default "zenbedded_mcu"
 
-config TIER_1
-    bool "Tier 1: Native ROS 2 Integration (Zenbedded CDR)"
-config TIER_2
-    bool "Tier 2: High-Throughput Raw Numeric"
-config TIER_3
-    bool "Tier 3: Bit-Optimal Packed"
+    config ZENBEDDED_ZENOH_MODE
+        string "The mode for zenoh-pico peer/client"
+        default "client"
 
-endchoice
+    config ZENBEDDED_ZENOH_LOCATOR
+        string "The locator/address to connect to for zenoh-pico"
+        default ""
+
+    config ZENBEDDED_PUB_TOPIC
+        string "Name of the topic for publishing"
+        default "zenbedded/state"
+
+    config ZENBEDDED_SUB_TOPIC
+        string "name of the topic for subscribing"
+        default "zenbedded/cmd"
+
+    choice ZENBEDDED_TRANSPORT_TIER
+        prompt "Integration Tier"
+        default ZENBEDDED_TRANSPORT_TIER_1
+
+        config ZENBEDDED_TRANSPORT_TIER_1
+            bool "Tier 1: Native ROS 2 Integration (Zenbedded CDR)"
+        config ZENBEDDED_TRANSPORT_TIER_2
+            bool "Tier 2: High-Throughput Raw Numeric"
+        config ZENBEDDED_TRANSPORT_TIER_3
+            bool "Tier 3: Bit-Optimal Packed"
+
+    endchoice
+
+    config ZENBEDDED_MAX_STATE_BUFFER_SIZE
+        int "Maximum size of state message (for static allocation)"
+        default 256
+
+    config ZENBEDDED_MAX_CMD_BUFFER_SIZE
+        int "Maximum size of cmd message (for static allocation)"
+        default 256
+
 endmenu

--- a/zenbedded_transport/include/zenbedded_transport/serialization.h
+++ b/zenbedded_transport/include/zenbedded_transport/serialization.h
@@ -18,7 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#ifdef CONFIG_TIER_1
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 
 /**
  * @brief Context for JointState serialization and deserialization.
@@ -88,6 +88,6 @@ bool zcdr_deserialize_joint_command(
   const zcdr_joint_command_ctx_t * ctx, const uint8_t * in_buffer, size_t buffer_size,
   int32_t * out_stamp_sec, uint32_t * out_stamp_nanosec, double * out_values);
 
-#endif  // CONFIG_TIER_1
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 
 #endif  // ZENBEDDED_TRANSPORT__SERIALIZATION_H_

--- a/zenbedded_transport/include/zenbedded_transport/serialization.hpp
+++ b/zenbedded_transport/include/zenbedded_transport/serialization.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ZENBEDDED_TRANSPORT__SERIALIZATION_H_
-#define ZENBEDDED_TRANSPORT__SERIALIZATION_H_
+#ifndef ZENBEDDED_TRANSPORT__SERIALIZATION_HPP_
+#define ZENBEDDED_TRANSPORT__SERIALIZATION_HPP_
 
 #include <cstddef>
 #include <cstdint>
@@ -90,4 +90,4 @@ bool zcdr_deserialize_joint_command(
 
 #endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 
-#endif  // ZENBEDDED_TRANSPORT__SERIALIZATION_H_
+#endif  // ZENBEDDED_TRANSPORT__SERIALIZATION_HPP_

--- a/zenbedded_transport/include/zenbedded_transport/zenoh_transport.h
+++ b/zenbedded_transport/include/zenbedded_transport/zenoh_transport.h
@@ -15,6 +15,29 @@
 #ifndef ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_H_
 #define ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_H_
 
-// Function prototypes will go here
+#include <cstddef>
+#include <cstdint>
+
+// Generic callback operating purely on raw bytes
+typedef void (*zenbedded_sub_cb_t)(const uint8_t * payload, size_t size, void * user_data);
+
+typedef struct
+{
+  const char * name;
+  const char * type;
+  const char * rihs_hash;
+} zenbedded_topic_info_t;
+
+// Register generic subscriber callback with user context
+void zenbedded_set_subcriber_cb(zenbedded_sub_cb_t cb, void * user_data);
+
+// Initializes Zenoh session, node liveliness, pub/sub entities, and background tasks.
+int zenbedded_transport_init();
+
+// Publishes raw payload directly to the ROS 2 state topic.
+int zenbedded_publish(const uint8_t * payload, size_t size);
+
+// Closes Zenoh session and cleans up resources.
+void zenbedded_transport_close();
 
 #endif  // ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_H_

--- a/zenbedded_transport/include/zenbedded_transport/zenoh_transport.hpp
+++ b/zenbedded_transport/include/zenbedded_transport/zenoh_transport.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_H_
-#define ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_H_
+#ifndef ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_HPP_
+#define ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_HPP_
 
 #include <cstddef>
 #include <cstdint>
@@ -21,23 +21,16 @@
 // Generic callback operating purely on raw bytes
 typedef void (*zenbedded_sub_cb_t)(const uint8_t * payload, size_t size, void * user_data);
 
-typedef struct
-{
-  const char * name;
-  const char * type;
-  const char * rihs_hash;
-} zenbedded_topic_info_t;
-
 // Register generic subscriber callback with user context
-void zenbedded_set_subcriber_cb(zenbedded_sub_cb_t cb, void * user_data);
+void zenbedded_set_subscriber_cb(zenbedded_sub_cb_t cb, void * user_data);
 
 // Initializes Zenoh session, node liveliness, pub/sub entities, and background tasks.
 int zenbedded_transport_init();
 
-// Publishes raw payload directly to the ROS 2 state topic.
+// Publishes raw payload directly with zenoh publisher
 int zenbedded_publish(const uint8_t * payload, size_t size);
 
 // Closes Zenoh session and cleans up resources.
 void zenbedded_transport_close();
 
-#endif  // ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_H_
+#endif  // ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_HPP_

--- a/zenbedded_transport/src/serialization.cpp
+++ b/zenbedded_transport/src/serialization.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "zenbedded_transport/serialization.h"
+#include "zenbedded_transport/serialization.hpp"
 
-#include <string.h>
+#include <cstring>
 
 #ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 

--- a/zenbedded_transport/src/serialization.cpp
+++ b/zenbedded_transport/src/serialization.cpp
@@ -16,7 +16,7 @@
 
 #include <string.h>
 
-#ifdef CONFIG_TIER_1
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 
 #define CDR_HEADER_SIZE 4
 #define ALIGN_UP(offset, alignment) \
@@ -259,4 +259,4 @@ bool zcdr_deserialize_joint_command(
   return true;
 }
 
-#endif  // CONFIG_TIER_1
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1

--- a/zenbedded_transport/src/zenoh_transport.cpp
+++ b/zenbedded_transport/src/zenoh_transport.cpp
@@ -12,4 +12,315 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "zenbedded_transport/zenoh_transport.h"  // NOLINT(build/include_subdir)
+#include "zenbedded_transport/zenoh_transport.h"
+#include <zenoh-pico.h>
+#include <zephyr/logging/log.h>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+LOG_MODULE_REGISTER(zenbedded_transport, LOG_LEVEL_INF);
+
+#define RMW_GID_SIZE 16
+#define KEYEXPR_SIZE 400
+#define TOPIC_MAX_NAME 124
+
+// RMW Attachment structure required by rmw_zenoh
+typedef struct __attribute__((__packed__))
+{
+  int64_t sequence_number;
+  int64_t time;
+  uint8_t rmw_gid_size;
+  uint8_t rmw_gid[RMW_GID_SIZE];
+} rmw_attachment_t;
+
+static z_owned_session_t s_session;
+static z_owned_publisher_t z_pub;
+static z_owned_subscriber_t z_sub;
+
+static z_owned_liveliness_token_t node_lv_token;
+static z_owned_liveliness_token_t pub_lv_token;
+static z_owned_liveliness_token_t sub_lv_token;
+
+static rmw_attachment_t pub_attachment;
+
+static zenbedded_sub_cb_t sub_cb = nullptr;  // callback provided by client for incoming commands
+static void * sub_user_data = nullptr;       // optional context info for callback
+
+static zenbedded_topic_info_t pub_topic = {
+  .name = CONFIG_ZENBEDDED_PUB_TOPIC,
+  .type = "zenbedded_interfaces::msg::dds_::ZenbeddedCommand_",
+  .rihs_hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"};
+static zenbedded_topic_info_t sub_topic = {
+  .name = CONFIG_ZENBEDDED_SUB_TOPIC,
+  .type = "zenbedded_interfaces::msg::dds_::ZenbeddedState_",
+  .rihs_hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"};
+
+static void gen_random_gid(uint8_t * gid)
+{
+  for (int i = 0; i < RMW_GID_SIZE; i++)
+  {
+    gid[i] = z_random_u8();
+  }
+}
+
+static int generate_topic_keyexpr(
+  uint32_t domain_id, const zenbedded_topic_info_t * topic, char * keyexpr)
+{
+  return snprintf(
+    keyexpr, KEYEXPR_SIZE, "%" PRIu32 "/%s/%s_/RIHS01_%s", domain_id, topic->name, topic->type,
+    topic->rihs_hash);
+}
+
+// Generates Node Liveliness: @ros2_lv/<domain_id>/<session_id>/0/0/NN/%/%/<node_name>
+static int generate_node_liveliness_keyexpr(
+  uint32_t domain_id, const char * node_name, char * keyexpr)
+{
+  z_id_t id = z_info_zid(z_session_loan(&s_session));
+  return snprintf(
+    keyexpr, KEYEXPR_SIZE,
+    "@ros2_lv/%" PRIu32
+    "/%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x/"
+    "0/0/NN/%%/%%/%s",
+    domain_id, id.id[0], id.id[1], id.id[2], id.id[3], id.id[4], id.id[5], id.id[6], id.id[7],
+    id.id[8], id.id[9], id.id[10], id.id[11], id.id[12], id.id[13], id.id[14], id.id[15],
+    node_name);
+}
+
+// Generates Entity Liveliness (MP for Pub, MS for Sub):
+// @ros2_lv/<domain_id>/<session_id>/0/10/<entity_kind>/%/%/<node_name>/%<mangled_topic>/<type>_/RIHS01_<hash>/::,7:,:,:,,
+static int generate_entity_liveliness_keyexpr(
+  uint32_t domain_id, const char * node_name, const zenbedded_topic_info_t * topic,
+  const char * entity_str, char * keyexpr)
+{
+  char mangled_topic[TOPIC_MAX_NAME] = {0};
+  strncpy(mangled_topic, topic->name, TOPIC_MAX_NAME - 1);
+
+  // Mangle slashes '/' to '%' for rmw_zenoh liveliness tokens
+  for (char * p = mangled_topic; *p; p++)
+  {
+    if (*p == '/')
+    {
+      *p = '%';
+    }
+  }
+
+  z_id_t id = z_info_zid(z_session_loan(&s_session));
+
+  return snprintf(
+    keyexpr, KEYEXPR_SIZE,
+    "@ros2_lv/%" PRIu32
+    "/"
+    "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x/"
+    "0/10/%s/%%/%%/%s/%%%s/%s_/RIHS01_%s/::,7:,:,:,,",
+    domain_id, id.id[0], id.id[1], id.id[2], id.id[3], id.id[4], id.id[5], id.id[6], id.id[7],
+    id.id[8], id.id[9], id.id[10], id.id[11], id.id[12], id.id[13], id.id[14], id.id[15],
+    entity_str, node_name, mangled_topic, topic->type, topic->rihs_hash);
+}
+
+// Internal Subscriber Callback handler
+static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
+{
+  if (!sub_cb)
+  {
+    return;
+  }
+
+  size_t len = _z_bytes_len(z_sample_payload(sample));
+  if (len == 0 || len > CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE)
+  {
+    LOG_WRN(
+      "Subscriber payload size %zu exceeds cmd buffer limit (%d)", len,
+      CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE);
+    return;
+  }
+
+  static uint8_t stack_buf[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
+  z_bytes_reader_t reader = z_bytes_get_reader(z_sample_payload(sample));
+  z_bytes_reader_read(&reader, stack_buf, len);
+
+  sub_cb(stack_buf, len, sub_user_data);
+}
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+static int configure_zenoh_tier1()
+{
+  char keyexpr[KEYEXPR_SIZE];
+  z_view_keyexpr_t ke;
+
+  // Declare Node Liveliness Token
+  generate_node_liveliness_keyexpr(
+    CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, CONFIG_ZENBEDDED_ROS2_NODE_NAME, keyexpr);
+  z_view_keyexpr_from_str(&ke, keyexpr);
+  if (
+    z_liveliness_declare_token(
+      z_session_loan(&s_session), &node_lv_token, z_view_keyexpr_loan(&ke), nullptr) != Z_OK)
+  {
+    LOG_ERR("Failed to declare node liveliness token");
+  }
+
+  // Declare Publisher with rmw attachment
+  generate_topic_keyexpr(CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, &pub_topic, keyexpr);
+  z_view_keyexpr_from_str_unchecked(&ke, keyexpr);
+  pub_attachment.rmw_gid_size = RMW_GID_SIZE;
+  gen_random_gid(pub_attachment.rmw_gid);
+  pub_attachment.sequence_number = 0;
+  if (
+    z_declare_publisher(z_session_loan(&s_session), &z_pub, z_view_keyexpr_loan(&ke), nullptr) !=
+    Z_OK)
+  {
+    LOG_ERR("Failed to declare publisher");
+    return -1;
+  }
+
+  // Publisher Liveliness Token
+  generate_entity_liveliness_keyexpr(
+    CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, CONFIG_ZENBEDDED_ROS2_NODE_NAME, &pub_topic, "MP", keyexpr);
+  z_view_keyexpr_from_str(&ke, keyexpr);
+  z_liveliness_declare_token(
+    z_session_loan(&s_session), &pub_lv_token, z_view_keyexpr_loan(&ke), nullptr);
+
+  // Declare Subscriber
+  generate_topic_keyexpr(CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, &sub_topic, keyexpr);
+  z_view_keyexpr_from_str_unchecked(&ke, keyexpr);
+  z_owned_closure_sample_t callback;
+  z_closure_sample(&callback, zenoh_sub_handler, nullptr, nullptr);
+  if (
+    z_declare_subscriber(
+      z_session_loan(&s_session), &z_sub, z_view_keyexpr_loan(&ke),
+      z_closure_sample_move(&callback), nullptr) != Z_OK)
+  {
+    LOG_ERR("Failed to declare subscriber");
+    return -1;
+  }
+
+  // Subscriber Liveliness token
+  generate_entity_liveliness_keyexpr(
+    CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, CONFIG_ZENBEDDED_ROS2_NODE_NAME, &sub_topic, "MS", keyexpr);
+  z_view_keyexpr_from_str(&ke, keyexpr);
+  z_liveliness_declare_token(
+    z_session_loan(&s_session), &sub_lv_token, z_view_keyexpr_loan(&ke), nullptr);
+
+  return Z_OK;
+}
+#endif
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_2
+static int configure_zenoh_tier2()
+{
+  z_view_keyexpr_t ke;
+
+  // Declare publisher
+  z_view_keyexpr_from_str(&ke, CONFIG_ZENBEDDED_PUB_TOPIC);
+  if (
+    z_declare_publisher(z_session_loan(&s_session), &z_pub, z_view_keyexpr_loan(&ke), nullptr) !=
+    Z_OK)
+  {
+    LOG_ERR("Failed to declare publisher");
+    return -1;
+  }
+
+  // Declare Subscriber
+  z_owned_closure_sample_t callback;
+  z_view_keyexpr_from_str(&ke, CONFIG_ZENBEDDED_SUB_TOPIC);
+  z_closure_sample(&callback, zenoh_sub_handler, nullptr, nullptr);
+  if (
+    z_declare_subscriber(
+      z_session_loan(&s_session), &z_sub, z_view_keyexpr_loan(&ke),
+      z_closure_sample_move(&callback), nullptr) != Z_OK)
+  {
+    LOG_ERR("Failed to declare subscriber");
+    return -1;
+  }
+
+  return Z_OK;
+}
+#endif
+
+void zenbedded_set_subcriber_cb(zenbedded_sub_cb_t cb, void * user_data)
+{
+  sub_cb = cb;
+  sub_user_data = user_data;
+}
+
+int zenbedded_transport_init()
+{
+  z_owned_config_t z_config;
+  z_config_default(&z_config);
+
+  zp_config_insert(z_config_loan_mut(&z_config), Z_CONFIG_MODE_KEY, CONFIG_ZENBEDDED_ZENOH_MODE);
+  if (strcmp(CONFIG_ZENBEDDED_ZENOH_LOCATOR, "") != 0)
+  {
+    zp_config_insert(
+      z_config_loan_mut(&z_config),
+      (strcmp(CONFIG_ZENBEDDED_ZENOH_MODE, "client") == 0) ? Z_CONFIG_CONNECT_KEY
+                                                           : Z_CONFIG_LISTEN_KEY,
+      CONFIG_ZENBEDDED_ZENOH_LOCATOR);
+  }
+
+  if (z_open(&s_session, z_config_move(&z_config), nullptr) != Z_OK)
+  {
+    LOG_ERR("Failed to open Zenoh session");
+    return -1;
+  }
+
+  // Start lease and read tasks
+  zp_start_read_task(z_session_loan_mut(&s_session), nullptr);
+  zp_start_lease_task(z_session_loan_mut(&s_session), nullptr);
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+  if (configure_zenoh_tier1() != Z_OK)
+  {
+    return -1;
+  }
+#endif
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_2
+  if (configure_zenoh_tier2() != Z_OK)
+  {
+    return -1;
+  }
+#endif
+
+  return Z_OK;
+}
+
+int zenbedded_publish(const uint8_t * payload, size_t size)
+{
+  z_publisher_put_options_t options;
+  z_publisher_put_options_default(&options);
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+  pub_attachment.sequence_number++;
+  pub_attachment.time = z_clock_now().tv_nsec;
+
+  z_owned_bytes_t z_attachment;
+  z_bytes_from_static_buf(
+    &z_attachment, reinterpret_cast<const uint8_t *>(&pub_attachment), sizeof(rmw_attachment_t));
+  options.attachment = z_bytes_move(&z_attachment);
+#endif
+
+  z_owned_bytes_t zbytes;
+  z_bytes_from_static_buf(&zbytes, payload, size);
+
+  if (z_publisher_put(z_publisher_loan(&z_pub), z_bytes_move(&zbytes), &options) != Z_OK)
+  {
+    LOG_ERR("Failed to publish payload");
+    return -1;
+  }
+  return Z_OK;
+}
+
+void zenbedded_transport_close()
+{
+  z_liveliness_token_drop(z_liveliness_token_move(&sub_lv_token));
+  z_liveliness_token_drop(z_liveliness_token_move(&pub_lv_token));
+  z_liveliness_token_drop(z_liveliness_token_move(&node_lv_token));
+
+  z_undeclare_subscriber(z_subscriber_move(&z_sub));
+  z_undeclare_publisher(z_publisher_move(&z_pub));
+
+  zp_stop_lease_task(z_session_loan_mut(&s_session));
+  zp_stop_read_task(z_session_loan_mut(&s_session));
+
+  z_close(z_session_loan_mut(&s_session), nullptr);
+}

--- a/zenbedded_transport/src/zenoh_transport.cpp
+++ b/zenbedded_transport/src/zenoh_transport.cpp
@@ -14,12 +14,12 @@
 
 #include "zenbedded_transport/zenoh_transport.h"
 #include <zenoh-pico.h>
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
 
 LOG_MODULE_REGISTER(zenbedded_transport, LOG_LEVEL_INF);
 
@@ -48,10 +48,6 @@ static rmw_attachment_t pub_attachment;
 
 static zenbedded_sub_cb_t sub_cb = nullptr;  // callback provided by client for incoming commands
 static void * sub_user_data = nullptr;       // optional context info for callback
-
-static k_spinlock time_syncing_lock;
-static int64_t epoch_offset_ns = 0;  // time offset between mcu time and ros2 host pc time
-static bool time_synced = false;
 
 static zenbedded_topic_info_t pub_topic = {
   .name = CONFIG_ZENBEDDED_PUB_TOPIC,
@@ -124,55 +120,6 @@ static int generate_entity_liveliness_keyexpr(
     entity_str, node_name, mangled_topic, topic->type, topic->rihs_hash);
 }
 
-#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
-static void sync_mcu_time_from_ros2_payload(const uint8_t * payload, size_t len)
-{
-  // Need at least 12 bytes: 4 (CDR Header) + 4 (sec) + 4 (nanosec)
-  if (len < 12)
-  {
-    LOG_ERR("The Command payload is too small to be a ros2 message (Got %zu bytes)", len);
-    return;
-  }
-
-  int32_t sec = 0;
-  uint32_t nsec = 0;
-
-  if (payload[1] == 0x01)
-  {
-    sec = static_cast<int32_t>(sys_get_le32(&payload[4]));
-    nsec = sys_get_le32(&payload[8]);
-  }
-  else
-  {
-    sec = static_cast<int32_t>(sys_get_be32(&payload[4]));
-    nsec = sys_get_be32(&payload[8]);
-  }
-
-  // Ensure sec is a valid Unix timestamp (> 1.7 Billion seconds / post-2024)
-  // and nanoseconds is within range (< 1 billion).
-  if (sec > 1700000000 && nsec < 1000000000U)
-  {
-    uint64_t host_time_ns = (static_cast<uint64_t>(sec) * 1000000000ULL) + nsec;
-    uint64_t mcu_uptime_ns = k_ticks_to_ns_floor64(k_uptime_ticks());
-    int64_t new_offset = static_cast<int64_t>(host_time_ns) - static_cast<int64_t>(mcu_uptime_ns);
-
-    k_spinlock_key_t key = k_spin_lock(&time_syncing_lock);
-    if (!time_synced)
-    {
-      epoch_offset_ns = new_offset;
-      time_synced = true;
-      LOG_INF("Auto-synced MCU time from incoming ROS 2 CDR Header!");
-    }
-    else
-    {
-      // Smooth out network jitter with an Exponential Moving Average (EMA)
-      epoch_offset_ns = (epoch_offset_ns * 19 + new_offset) / 20;
-    }
-    k_spin_unlock(&time_syncing_lock, key);
-  }
-}
-#endif
-
 // Internal Subscriber Callback handler
 static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
 {
@@ -193,10 +140,6 @@ static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
   static uint8_t cmd_rx_buf[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
   z_bytes_reader_t reader = z_bytes_get_reader(z_sample_payload(sample));
   z_bytes_reader_read(&reader, cmd_rx_buf, len);
-
-#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
-  sync_mcu_time_from_ros2_payload(cmd_rx_buf, len);
-#endif
 
   sub_cb(cmd_rx_buf, len, sub_user_data);
 }
@@ -351,15 +294,9 @@ int zenbedded_publish(const uint8_t * payload, size_t size)
 
 #ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
   pub_attachment.sequence_number++;
-  k_spinlock_key_t key = k_spin_lock(&time_syncing_lock);
-  int64_t offset = epoch_offset_ns;
-  bool synced = time_synced;
-  k_spin_unlock(&time_syncing_lock, key);
-
-  uint64_t mcu_uptime_ns = k_ticks_to_ns_floor64(k_uptime_ticks());
-  pub_attachment.time =
-    synced ? static_cast<int64_t>(mcu_uptime_ns) + offset
-           : static_cast<int64_t>(mcu_uptime_ns);  // not real epoch time until synced
+  timespec tv;
+  clock_gettime(CLOCK_REALTIME, &tv);
+  pub_attachment.time = tv.tv_nsec;
 
   z_owned_bytes_t z_attachment;
   z_bytes_from_static_buf(

--- a/zenbedded_transport/src/zenoh_transport.cpp
+++ b/zenbedded_transport/src/zenoh_transport.cpp
@@ -102,12 +102,12 @@ static rmw_attachment_t pub_attachment;
 
 static zenbedded_ros2_topic_info_t pub_topic = {
   .name = CONFIG_ZENBEDDED_PUB_TOPIC,
-  .type = ZENBEDDED_CMD_MSG_TYPE_NAME,
-  .rihs_hash = ZENBEDDED_CMD_MSG_TYPE_HASH};
-static zenbedded_ros2_topic_info_t sub_topic = {
-  .name = CONFIG_ZENBEDDED_SUB_TOPIC,
   .type = ZENBEDDED_STATE_MSG_TYPE_NAME,
   .rihs_hash = ZENBEDDED_STATE_MSG_TYPE_HASH};
+static zenbedded_ros2_topic_info_t sub_topic = {
+  .name = CONFIG_ZENBEDDED_SUB_TOPIC,
+  .type = ZENBEDDED_CMD_MSG_TYPE_NAME,
+  .rihs_hash = ZENBEDDED_CMD_MSG_TYPE_HASH};
 
 #endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 
@@ -150,7 +150,7 @@ static int generate_topic_keyexpr(
   uint32_t domain_id, const zenbedded_ros2_topic_info_t * topic, char * keyexpr)
 {
   return snprintf(
-    keyexpr, KEYEXPR_SIZE, "%" PRIu32 "/%s/%s_/RIHS01_%s", domain_id, topic->name, topic->type,
+    keyexpr, KEYEXPR_SIZE, "%" PRIu32 "/%s/%s_/%s", domain_id, topic->name, topic->type,
     topic->rihs_hash);
 }
 
@@ -194,7 +194,7 @@ static int generate_entity_liveliness_keyexpr(
     "@ros2_lv/%" PRIu32
     "/"
     "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x/"
-    "0/10/%s/%%/%%/%s/%%%s/%s_/RIHS01_%s/::,7:,:,:,,",
+    "0/10/%s/%%/%%/%s/%%%s/%s_/%s/::,7:,:,:,,",
     domain_id, id.id[0], id.id[1], id.id[2], id.id[3], id.id[4], id.id[5], id.id[6], id.id[7],
     id.id[8], id.id[9], id.id[10], id.id[11], id.id[12], id.id[13], id.id[14], id.id[15],
     entity_str, node_name, mangled_topic, topic->type, topic->rihs_hash);

--- a/zenbedded_transport/src/zenoh_transport.cpp
+++ b/zenbedded_transport/src/zenoh_transport.cpp
@@ -14,7 +14,9 @@
 
 #include "zenbedded_transport/zenoh_transport.h"
 #include <zenoh-pico.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
@@ -46,6 +48,10 @@ static rmw_attachment_t pub_attachment;
 
 static zenbedded_sub_cb_t sub_cb = nullptr;  // callback provided by client for incoming commands
 static void * sub_user_data = nullptr;       // optional context info for callback
+
+static k_spinlock time_syncing_lock;
+static int64_t epoch_offset_ns = 0;  // time offset between mcu time and ros2 host pc time
+static bool time_synced = false;
 
 static zenbedded_topic_info_t pub_topic = {
   .name = CONFIG_ZENBEDDED_PUB_TOPIC,
@@ -118,6 +124,55 @@ static int generate_entity_liveliness_keyexpr(
     entity_str, node_name, mangled_topic, topic->type, topic->rihs_hash);
 }
 
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+static void sync_mcu_time_from_ros2_payload(const uint8_t * payload, size_t len)
+{
+  // Need at least 12 bytes: 4 (CDR Header) + 4 (sec) + 4 (nanosec)
+  if (len < 12)
+  {
+    LOG_ERR("The Command payload is too small to be a ros2 message (Got %zu bytes)", len);
+    return;
+  }
+
+  int32_t sec = 0;
+  uint32_t nsec = 0;
+
+  if (payload[1] == 0x01)
+  {
+    sec = static_cast<int32_t>(sys_get_le32(&payload[4]));
+    nsec = sys_get_le32(&payload[8]);
+  }
+  else
+  {
+    sec = static_cast<int32_t>(sys_get_be32(&payload[4]));
+    nsec = sys_get_be32(&payload[8]);
+  }
+
+  // Ensure sec is a valid Unix timestamp (> 1.7 Billion seconds / post-2024)
+  // and nanoseconds is within range (< 1 billion).
+  if (sec > 1700000000 && nsec < 1000000000U)
+  {
+    uint64_t host_time_ns = (static_cast<uint64_t>(sec) * 1000000000ULL) + nsec;
+    uint64_t mcu_uptime_ns = k_ticks_to_ns_floor64(k_uptime_ticks());
+    int64_t new_offset = static_cast<int64_t>(host_time_ns) - static_cast<int64_t>(mcu_uptime_ns);
+
+    k_spinlock_key_t key = k_spin_lock(&time_syncing_lock);
+    if (!time_synced)
+    {
+      epoch_offset_ns = new_offset;
+      time_synced = true;
+      LOG_INF("Auto-synced MCU time from incoming ROS 2 CDR Header!");
+    }
+    else
+    {
+      // Smooth out network jitter with an Exponential Moving Average (EMA)
+      epoch_offset_ns = (epoch_offset_ns * 19 + new_offset) / 20;
+    }
+    k_spin_unlock(&time_syncing_lock, key);
+  }
+}
+#endif
+
 // Internal Subscriber Callback handler
 static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
 {
@@ -138,6 +193,10 @@ static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
   static uint8_t cmd_rx_buf[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
   z_bytes_reader_t reader = z_bytes_get_reader(z_sample_payload(sample));
   z_bytes_reader_read(&reader, cmd_rx_buf, len);
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+  sync_mcu_time_from_ros2_payload(cmd_rx_buf, len);
+#endif
 
   sub_cb(cmd_rx_buf, len, sub_user_data);
 }
@@ -292,8 +351,15 @@ int zenbedded_publish(const uint8_t * payload, size_t size)
 
 #ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
   pub_attachment.sequence_number++;
-  z_clock_t now = z_clock_now();
-  pub_attachment.time = now.tv_sec * 1000000000LL + now.tv_nsec;
+  k_spinlock_key_t key = k_spin_lock(&time_syncing_lock);
+  int64_t offset = epoch_offset_ns;
+  bool synced = time_synced;
+  k_spin_unlock(&time_syncing_lock, key);
+
+  uint64_t mcu_uptime_ns = k_ticks_to_ns_floor64(k_uptime_ticks());
+  pub_attachment.time =
+    synced ? static_cast<int64_t>(mcu_uptime_ns) + offset
+           : static_cast<int64_t>(mcu_uptime_ns);  // not real epoch time until synced
 
   z_owned_bytes_t z_attachment;
   z_bytes_from_static_buf(

--- a/zenbedded_transport/src/zenoh_transport.cpp
+++ b/zenbedded_transport/src/zenoh_transport.cpp
@@ -126,7 +126,7 @@ static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
     return;
   }
 
-  size_t len = _z_bytes_len(z_sample_payload(sample));
+  size_t len = z_bytes_len(z_sample_payload(sample));
   if (len == 0 || len > CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE)
   {
     LOG_WRN(
@@ -135,11 +135,11 @@ static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
     return;
   }
 
-  static uint8_t stack_buf[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
+  static uint8_t cmd_rx_buf[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
   z_bytes_reader_t reader = z_bytes_get_reader(z_sample_payload(sample));
-  z_bytes_reader_read(&reader, stack_buf, len);
+  z_bytes_reader_read(&reader, cmd_rx_buf, len);
 
-  sub_cb(stack_buf, len, sub_user_data);
+  sub_cb(cmd_rx_buf, len, sub_user_data);
 }
 
 #ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
@@ -157,6 +157,7 @@ static int configure_zenoh_tier1()
       z_session_loan(&s_session), &node_lv_token, z_view_keyexpr_loan(&ke), nullptr) != Z_OK)
   {
     LOG_ERR("Failed to declare node liveliness token");
+    return -1;
   }
 
   // Declare Publisher with rmw attachment
@@ -237,7 +238,7 @@ static int configure_zenoh_tier2()
 }
 #endif
 
-void zenbedded_set_subcriber_cb(zenbedded_sub_cb_t cb, void * user_data)
+void zenbedded_set_subscriber_cb(zenbedded_sub_cb_t cb, void * user_data)
 {
   sub_cb = cb;
   sub_user_data = user_data;

--- a/zenbedded_transport/src/zenoh_transport.cpp
+++ b/zenbedded_transport/src/zenoh_transport.cpp
@@ -291,7 +291,8 @@ int zenbedded_publish(const uint8_t * payload, size_t size)
 
 #ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
   pub_attachment.sequence_number++;
-  pub_attachment.time = z_clock_now().tv_nsec;
+  z_clock_t now = z_clock_now();
+  pub_attachment.time = now.tv_sec * 1000000000LL + now.tv_nsec;
 
   z_owned_bytes_t z_attachment;
   z_bytes_from_static_buf(

--- a/zenbedded_transport/src/zenoh_transport.cpp
+++ b/zenbedded_transport/src/zenoh_transport.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "zenbedded_transport/zenoh_transport.h"
+#include "zenbedded_transport/zenoh_transport.hpp"
 #include <zenoh-pico.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
@@ -23,9 +23,25 @@
 
 LOG_MODULE_REGISTER(zenbedded_transport, LOG_LEVEL_INF);
 
+static zenbedded_sub_cb_t sub_cb = nullptr;  // callback provided by client for incoming CMDs
+static void * sub_user_data = nullptr;       // optional context info for callback
+
+static z_owned_session_t s_session;
+static z_owned_publisher_t z_pub;
+static z_owned_subscriber_t z_sub;
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+
 #define RMW_GID_SIZE 16
 #define KEYEXPR_SIZE 400
 #define TOPIC_MAX_NAME 124
+
+typedef struct
+{
+  const char * name;
+  const char * type;
+  const char * rihs_hash;
+} zenbedded_ros2_topic_info_t;
 
 // RMW Attachment structure required by rmw_zenoh
 typedef struct __attribute__((__packed__))
@@ -36,27 +52,91 @@ typedef struct __attribute__((__packed__))
   uint8_t rmw_gid[RMW_GID_SIZE];
 } rmw_attachment_t;
 
-static z_owned_session_t s_session;
-static z_owned_publisher_t z_pub;
-static z_owned_subscriber_t z_sub;
-
 static z_owned_liveliness_token_t node_lv_token;
 static z_owned_liveliness_token_t pub_lv_token;
 static z_owned_liveliness_token_t sub_lv_token;
 
 static rmw_attachment_t pub_attachment;
 
-static zenbedded_sub_cb_t sub_cb = nullptr;  // callback provided by client for incoming commands
-static void * sub_user_data = nullptr;       // optional context info for callback
+#ifdef CONFIG_ZENBEDDED_STATE_MSG_IMU
+#define ZENBEDDED_STATE_MSG_TYPE_NAME "sensor_msgs::msg::dds_::Imu"
+#define ZENBEDDED_STATE_MSG_TYPE_HASH \
+  "RIHS01_7d9a00ff131080897a5ec7e26e315954b8eae3353c3f995c55faf71574000b5b"
+#endif  // CONFIG_ZENBEDDED_STATE_MSG_IMU
 
-static zenbedded_topic_info_t pub_topic = {
+#ifdef CONFIG_ZENBEDDED_STATE_MSG_JOINT_STATE
+#define ZENBEDDED_STATE_MSG_TYPE_NAME "sensor_msgs::msg::dds_::JointState"
+#define ZENBEDDED_STATE_MSG_TYPE_HASH \
+  "RIHS01_a13ee3a330e346c9d87b5aa18d24e11690752bd33a0350f11c5882bc9179260e"
+#endif  // CONFIG_ZENBEDDED_STATE_MSG_JOINT_STATE
+
+#ifdef CONFIG_ZENBEDDED_STATE_MSG_FLOAT64_MULTI_ARRAY
+#define ZENBEDDED_STATE_MSG_TYPE_NAME "std_msgs::msg::dds_::Float64MultiArray"
+#define ZENBEDDED_STATE_MSG_TYPE_HASH \
+  "RIHS01_1025ddc6b9552d191f89ef1a8d2f60f3d373e28b283d8891ddcc974e8c55397f"
+#endif  // CONFIG_ZENBEDDED_STATE_MSG_FLOAT64_MULTI_ARRAY
+
+#ifdef CONFIG_ZENBEDDED_STATE_MSG_TWIST
+#define ZENBEDDED_STATE_MSG_TYPE_NAME "geometry_msgs::msg::dds_::Twist"
+#define ZENBEDDED_STATE_MSG_TYPE_HASH \
+  "RIHS01_9c45bf16fe0983d80e3cfe750d6835843d265a9a6c46bd2e609fcddde6fb8d2a"
+#endif  // CONFIG_ZENBEDDED_STATE_MSG_TWIST
+
+#ifdef CONFIG_ZENBEDDED_CMD_MSG_JOINT_COMMAND
+#define ZENBEDDED_CMD_MSG_TYPE_NAME "control_msgs::msg::dds_::JointCommand"
+#define ZENBEDDED_CMD_MSG_TYPE_HASH \
+  "RIHS01_6080a1df9d28b6badffa5efb27d4ba4ae657c4f6dd2b519b178a32db12405985"
+#endif  // CONFIG_ZENBEDDED_CMD_MSG_JOINT_COMMAND
+
+#ifdef CONFIG_ZENBEDDED_CMD_MSG_FLOAT64_MULTI_ARRAY
+#define ZENBEDDED_CMD_MSG_TYPE_NAME "std_msgs::msg::dds_::Float64MultiArray"
+#define ZENBEDDED_CMD_MSG_TYPE_HASH \
+  "RIHS01_1025ddc6b9552d191f89ef1a8d2f60f3d373e28b283d8891ddcc974e8c55397f"
+#endif  // CONFIG_ZENBEDDED_CMD_MSG_FLOAT64_MULTI_ARRAY
+
+#ifdef CONFIG_ZENBEDDED_CMD_MSG_TWIST
+#define ZENBEDDED_CMD_MSG_TYPE_NAME "geometry_msgs::msg::dds_::Twist"
+#define ZENBEDDED_CMD_MSG_TYPE_HASH \
+  "RIHS01_9c45bf16fe0983d80e3cfe750d6835843d265a9a6c46bd2e609fcddde6fb8d2a"
+#endif  // CONFIG_ZENBEDDED_CMD_MSG_TWIST
+
+static zenbedded_ros2_topic_info_t pub_topic = {
   .name = CONFIG_ZENBEDDED_PUB_TOPIC,
-  .type = "zenbedded_interfaces::msg::dds_::ZenbeddedCommand_",
-  .rihs_hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"};
-static zenbedded_topic_info_t sub_topic = {
+  .type = ZENBEDDED_CMD_MSG_TYPE_NAME,
+  .rihs_hash = ZENBEDDED_CMD_MSG_TYPE_HASH};
+static zenbedded_ros2_topic_info_t sub_topic = {
   .name = CONFIG_ZENBEDDED_SUB_TOPIC,
-  .type = "zenbedded_interfaces::msg::dds_::ZenbeddedState_",
-  .rihs_hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"};
+  .type = ZENBEDDED_STATE_MSG_TYPE_NAME,
+  .rihs_hash = ZENBEDDED_STATE_MSG_TYPE_HASH};
+
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1
+
+// Internal Subscriber Callback handler
+static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
+{
+  if (!sub_cb)
+  {
+    return;
+  }
+  LOG_INF("Incoming sample from ros2");
+
+  const size_t len = z_bytes_len(z_sample_payload(sample));
+  if (len == 0 || len > CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE)
+  {
+    LOG_WRN(
+      "Subscriber payload size %zu exceeds cmd buffer limit (%d)", len,
+      CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE);
+    return;
+  }
+
+  static uint8_t cmd_rx_buf[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
+  z_bytes_reader_t reader = z_bytes_get_reader(z_sample_payload(sample));
+  z_bytes_reader_read(&reader, cmd_rx_buf, len);
+
+  sub_cb(cmd_rx_buf, len, sub_user_data);
+}
+
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 
 static void gen_random_gid(uint8_t * gid)
 {
@@ -67,7 +147,7 @@ static void gen_random_gid(uint8_t * gid)
 }
 
 static int generate_topic_keyexpr(
-  uint32_t domain_id, const zenbedded_topic_info_t * topic, char * keyexpr)
+  uint32_t domain_id, const zenbedded_ros2_topic_info_t * topic, char * keyexpr)
 {
   return snprintf(
     keyexpr, KEYEXPR_SIZE, "%" PRIu32 "/%s/%s_/RIHS01_%s", domain_id, topic->name, topic->type,
@@ -92,7 +172,7 @@ static int generate_node_liveliness_keyexpr(
 // Generates Entity Liveliness (MP for Pub, MS for Sub):
 // @ros2_lv/<domain_id>/<session_id>/0/10/<entity_kind>/%/%/<node_name>/%<mangled_topic>/<type>_/RIHS01_<hash>/::,7:,:,:,,
 static int generate_entity_liveliness_keyexpr(
-  uint32_t domain_id, const char * node_name, const zenbedded_topic_info_t * topic,
+  uint32_t domain_id, const char * node_name, const zenbedded_ros2_topic_info_t * topic,
   const char * entity_str, char * keyexpr)
 {
   char mangled_topic[TOPIC_MAX_NAME] = {0};
@@ -120,39 +200,13 @@ static int generate_entity_liveliness_keyexpr(
     entity_str, node_name, mangled_topic, topic->type, topic->rihs_hash);
 }
 
-// Internal Subscriber Callback handler
-static void zenoh_sub_handler(z_loaned_sample_t * sample, void * ctx)
-{
-  if (!sub_cb)
-  {
-    return;
-  }
-
-  size_t len = z_bytes_len(z_sample_payload(sample));
-  if (len == 0 || len > CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE)
-  {
-    LOG_WRN(
-      "Subscriber payload size %zu exceeds cmd buffer limit (%d)", len,
-      CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE);
-    return;
-  }
-
-  static uint8_t cmd_rx_buf[CONFIG_ZENBEDDED_MAX_CMD_BUFFER_SIZE];
-  z_bytes_reader_t reader = z_bytes_get_reader(z_sample_payload(sample));
-  z_bytes_reader_read(&reader, cmd_rx_buf, len);
-
-  sub_cb(cmd_rx_buf, len, sub_user_data);
-}
-
-#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 static int configure_zenoh_tier1()
 {
   char keyexpr[KEYEXPR_SIZE];
   z_view_keyexpr_t ke;
 
   // Declare Node Liveliness Token
-  generate_node_liveliness_keyexpr(
-    CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, CONFIG_ZENBEDDED_ROS2_NODE_NAME, keyexpr);
+  generate_node_liveliness_keyexpr(CONFIG_ZENBEDDED_DOMAIN_ID, CONFIG_ZENBEDDED_NODE_NAME, keyexpr);
   z_view_keyexpr_from_str(&ke, keyexpr);
   if (
     z_liveliness_declare_token(
@@ -163,7 +217,7 @@ static int configure_zenoh_tier1()
   }
 
   // Declare Publisher with rmw attachment
-  generate_topic_keyexpr(CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, &pub_topic, keyexpr);
+  generate_topic_keyexpr(CONFIG_ZENBEDDED_DOMAIN_ID, &pub_topic, keyexpr);
   z_view_keyexpr_from_str_unchecked(&ke, keyexpr);
   pub_attachment.rmw_gid_size = RMW_GID_SIZE;
   gen_random_gid(pub_attachment.rmw_gid);
@@ -178,13 +232,13 @@ static int configure_zenoh_tier1()
 
   // Publisher Liveliness Token
   generate_entity_liveliness_keyexpr(
-    CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, CONFIG_ZENBEDDED_ROS2_NODE_NAME, &pub_topic, "MP", keyexpr);
+    CONFIG_ZENBEDDED_DOMAIN_ID, CONFIG_ZENBEDDED_NODE_NAME, &pub_topic, "MP", keyexpr);
   z_view_keyexpr_from_str(&ke, keyexpr);
   z_liveliness_declare_token(
     z_session_loan(&s_session), &pub_lv_token, z_view_keyexpr_loan(&ke), nullptr);
 
   // Declare Subscriber
-  generate_topic_keyexpr(CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, &sub_topic, keyexpr);
+  generate_topic_keyexpr(CONFIG_ZENBEDDED_DOMAIN_ID, &sub_topic, keyexpr);
   z_view_keyexpr_from_str_unchecked(&ke, keyexpr);
   z_owned_closure_sample_t callback;
   z_closure_sample(&callback, zenoh_sub_handler, nullptr, nullptr);
@@ -199,14 +253,14 @@ static int configure_zenoh_tier1()
 
   // Subscriber Liveliness token
   generate_entity_liveliness_keyexpr(
-    CONFIG_ZENBEDDED_ROS2_DOMAIN_ID, CONFIG_ZENBEDDED_ROS2_NODE_NAME, &sub_topic, "MS", keyexpr);
+    CONFIG_ZENBEDDED_DOMAIN_ID, CONFIG_ZENBEDDED_NODE_NAME, &sub_topic, "MS", keyexpr);
   z_view_keyexpr_from_str(&ke, keyexpr);
   z_liveliness_declare_token(
     z_session_loan(&s_session), &sub_lv_token, z_view_keyexpr_loan(&ke), nullptr);
 
   return Z_OK;
 }
-#endif
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 
 #ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_2
 static int configure_zenoh_tier2()
@@ -238,7 +292,7 @@ static int configure_zenoh_tier2()
 
   return Z_OK;
 }
-#endif
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_2
 
 void zenbedded_set_subscriber_cb(zenbedded_sub_cb_t cb, void * user_data)
 {
@@ -276,27 +330,27 @@ int zenbedded_transport_init()
   {
     return -1;
   }
-#endif
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_1
 #ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_2
   if (configure_zenoh_tier2() != Z_OK)
   {
     return -1;
   }
-#endif
+#endif  // CONFIG_ZENBEDDED_TRANSPORT_TIER_2
 
   return Z_OK;
 }
 
-int zenbedded_publish(const uint8_t * payload, size_t size)
+int zenbedded_publish(const uint8_t * payload, const size_t size)
 {
   z_publisher_put_options_t options;
   z_publisher_put_options_default(&options);
 
 #ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
   pub_attachment.sequence_number++;
-  timespec tv;
+  timespec tv{};
   clock_gettime(CLOCK_REALTIME, &tv);
-  pub_attachment.time = tv.tv_nsec;
+  pub_attachment.time = tv.tv_sec * 1000000000LL + tv.tv_nsec;
 
   z_owned_bytes_t z_attachment;
   z_bytes_from_static_buf(
@@ -317,9 +371,11 @@ int zenbedded_publish(const uint8_t * payload, size_t size)
 
 void zenbedded_transport_close()
 {
+#ifdef CONFIG_ZENBEDDED_TRANSPORT_TIER_1
   z_liveliness_token_drop(z_liveliness_token_move(&sub_lv_token));
   z_liveliness_token_drop(z_liveliness_token_move(&pub_lv_token));
   z_liveliness_token_drop(z_liveliness_token_move(&node_lv_token));
+#endif
 
   z_undeclare_subscriber(z_subscriber_move(&z_sub));
   z_undeclare_publisher(z_publisher_move(&z_pub));

--- a/zenbedded_transport_tests/CMakeLists.txt
+++ b/zenbedded_transport_tests/CMakeLists.txt
@@ -21,7 +21,7 @@ if(BUILD_TESTING)
   target_include_directories(zcdr_under_test PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../zenbedded_transport/include
   )
-  target_compile_definitions(zcdr_under_test PUBLIC CONFIG_TIER_1=1)
+  target_compile_definitions(zcdr_under_test PUBLIC CONFIG_ZENBEDDED_TRANSPORT_TIER_1=1)
 
   ament_add_gtest(test_cdr_conformance
     test/test_cdr_conformance.cpp

--- a/zenbedded_transport_tests/test/test_cdr_conformance.cpp
+++ b/zenbedded_transport_tests/test/test_cdr_conformance.cpp
@@ -22,7 +22,7 @@
 #include <rclcpp/serialized_message.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 
-#include "zenbedded_transport/serialization.h"
+#include "zenbedded_transport/serialization.hpp"
 
 namespace
 {


### PR DESCRIPTION
Extracted all direct zenoh-pico usage into a new zenbedded_transport layer and refactor ZenbeddedClient to be transport-agnostic. Add a clean transport API (zenoh_transport.hpp/zenoh_transport.cpp) that manages session lifecycle, publisher/subscriber declaration, ROS 2 liveliness tokens and rmw attachments, and a serialization tier (CDR/Tier1) via serialization.hpp. ZenbeddedClient is now a templated client (ZenbeddedClient<StateCodec,CommandCodec>) using codecs.hpp, double-buffered payloads, and the transport publish/subscribe API instead of calling zenoh-pico directly.

Key changes 
- New transport library: zenbedded_transport (CMake/Kconfig + zenoh_transport.hpp/cpp) that initializes zenoh, declares pub/sub, publishes raw payloads, and provides a generic subscriber callback.
- rmw/ROS2 integration: liveliness tokens, rmw_attachment (sequence_number/time/rmw_gid) for Tier-1 (rmw_zenoh) compatibility, and topic/type RIHS handling.
- Serialization layer: zenbedded_transport/serialization.{hpp,cpp} (Tier-1 CDR helpers) and new codecs.hpp under zenbedded_rcl exposing codec concepts and concrete codecs (JointState, JointCommand, Raw).
- ZenbeddedClient refactor: split into ZenbeddedClientBase + templated ZenbeddedClient<StateCodec,CommandCodec>, removed direct zenoh-pico usage from the RCL layer, double-buffering moved to raw byte buffers, thread and buffer logic modernized to use transport API.
- Build/config changes: Kconfig expanded for transport tiers, topics, buffer-size limits and message-type choices; CMake changes expose target_include_directories and link zenbedded_rcl against zenbedded_transport.
