### PR TITLE
Add dependencies for native_sim builds & patch arch failure on 32vs64bits

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,6 +50,10 @@ WORKDIR /zephyr_ws/modules/lib/zenoh-pico
 COPY docker/wrap_zenoh_config.patch .
 RUN git apply wrap_zenoh_config.patch && rm wrap_zenoh_config.patch
 
+# apply patch fixing socklen_t argument types, which only mismatch on 64-bit hosts
+COPY docker/fix_socklen_types.patch .
+RUN git apply fix_socklen_types.patch && rm fix_socklen_types.patch
+
 # Set environment variables
 ENV ZEPHYR_BASE=/zephyr_ws/zephyr
 ENV ZEPHYR_SDK_INSTALL_DIR=/zephyr_ws/zephyr-sdk-0.16.8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     cmake ninja-build gperf build-essential \
     ccache dfu-util device-tree-compiler wget \
     python3-dev python3-tk python3-wheel xz-utils file \
-    make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1 git \
+    make gcc libsdl2-dev libmagic1 git \
     ros-jazzy-ros2-control \
     ros-jazzy-ros2-controllers \
     ros-jazzy-rmw-zenoh-cpp \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,9 @@ RUN cd manifest-repo && git init -q && git add . \
 RUN west init -l manifest-repo && west update && west zephyr-export
 
 # Copy python requirements from zephyr and install
-RUN pip3 install --ignore-installed --break-system-packages -r /zephyr_ws/zephyr/scripts/requirements.txt
+RUN --mount=type=bind,source=docker/requirements.txt,target=/tmp/requirements.txt \
+    PIP_CONSTRAINT=/tmp/requirements.txt \
+    pip3 install --ignore-installed --break-system-packages -r /zephyr_ws/zephyr/scripts/requirements.txt
 
 # Install Zephyr SDK(MINIMAL)
 RUN ARCH=$(uname -m) && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     cmake ninja-build gperf build-essential \
     ccache dfu-util device-tree-compiler wget \
     python3-dev python3-tk python3-wheel xz-utils file \
-    make gcc libsdl2-dev libmagic1 git \
+    make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1 git \
     ros-jazzy-ros2-control \
     ros-jazzy-ros2-controllers \
     ros-jazzy-rmw-zenoh-cpp \
@@ -17,8 +17,9 @@ RUN apt-get update && apt-get install -y \
     ros-jazzy-rosidl-generator-cpp \
     && rm -rf /var/lib/apt/lists/*
 
-# Install West
-RUN pip3 install --break-system-packages west
+# Install Python workspace dependencies
+RUN --mount=type=bind,source=docker/requirements.txt,target=/tmp/requirements.txt \
+    pip3 install --ignore-installed --break-system-packages -r /tmp/requirements.txt
 
 # Set up Zephyr workspace with zenoh-pico preloaded
 WORKDIR /zephyr_ws

--- a/docker/fix_socklen_types.patch
+++ b/docker/fix_socklen_types.patch
@@ -3,7 +3,7 @@ index 731da21..468f8c1 100644
 --- a/src/system/zephyr/network.c
 +++ b/src/system/zephyr/network.c
 @@ -52,7 +52,7 @@ z_result_t _z_socket_set_non_blocking(const _z_sys_net_socket_t *sock) {
- 
+
  z_result_t _z_socket_accept(const _z_sys_net_socket_t *sock_in, _z_sys_net_socket_t *sock_out) {
      struct sockaddr naddr;
 -    unsigned int nlen = sizeof(naddr);
@@ -12,17 +12,17 @@ index 731da21..468f8c1 100644
      int con_socket = accept(sock_in->_fd, &naddr, &nlen);
      if (con_socket < 0) {
 @@ -373,7 +373,7 @@ void _z_close_udp_unicast(_z_sys_net_socket_t *sock) {
- 
+
  size_t _z_read_udp_unicast(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len) {
      struct sockaddr_storage raddr;
 -    unsigned int addrlen = sizeof(struct sockaddr_storage);
 +    socklen_t addrlen = sizeof(struct sockaddr_storage);
- 
+
      ssize_t rb = recvfrom(sock._fd, ptr, len, 0, (struct sockaddr *)&raddr, &addrlen);
      if (rb < (ssize_t)0) {
 @@ -413,7 +413,7 @@ z_result_t _z_open_udp_multicast(_z_sys_net_socket_t *sock, const _z_sys_net_end
      z_result_t ret = _Z_RES_OK;
- 
+
      struct sockaddr *lsockaddr = NULL;
 -    unsigned int addrlen = 0;
 +    socklen_t addrlen = 0;
@@ -31,7 +31,7 @@ index 731da21..468f8c1 100644
          if (lsockaddr != NULL) {
 @@ -516,7 +516,7 @@ z_result_t _z_listen_udp_multicast(_z_sys_net_socket_t *sock, const _z_sys_net_e
      z_result_t ret = _Z_RES_OK;
- 
+
      struct sockaddr *lsockaddr = NULL;
 -    unsigned int addrlen = 0;
 +    socklen_t addrlen = 0;
@@ -44,6 +44,6 @@ index 731da21..468f8c1 100644
      struct sockaddr_storage raddr;
 -    unsigned int raddrlen = sizeof(struct sockaddr_storage);
 +    socklen_t raddrlen = sizeof(struct sockaddr_storage);
- 
+
      ssize_t rb = 0;
      do {

--- a/docker/fix_socklen_types.patch
+++ b/docker/fix_socklen_types.patch
@@ -1,0 +1,49 @@
+diff --git a/src/system/zephyr/network.c b/src/system/zephyr/network.c
+index 731da21..468f8c1 100644
+--- a/src/system/zephyr/network.c
++++ b/src/system/zephyr/network.c
+@@ -52,7 +52,7 @@ z_result_t _z_socket_set_non_blocking(const _z_sys_net_socket_t *sock) {
+ 
+ z_result_t _z_socket_accept(const _z_sys_net_socket_t *sock_in, _z_sys_net_socket_t *sock_out) {
+     struct sockaddr naddr;
+-    unsigned int nlen = sizeof(naddr);
++    socklen_t nlen = sizeof(naddr);
+     sock_out->_fd = -1;
+     int con_socket = accept(sock_in->_fd, &naddr, &nlen);
+     if (con_socket < 0) {
+@@ -373,7 +373,7 @@ void _z_close_udp_unicast(_z_sys_net_socket_t *sock) {
+ 
+ size_t _z_read_udp_unicast(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len) {
+     struct sockaddr_storage raddr;
+-    unsigned int addrlen = sizeof(struct sockaddr_storage);
++    socklen_t addrlen = sizeof(struct sockaddr_storage);
+ 
+     ssize_t rb = recvfrom(sock._fd, ptr, len, 0, (struct sockaddr *)&raddr, &addrlen);
+     if (rb < (ssize_t)0) {
+@@ -413,7 +413,7 @@ z_result_t _z_open_udp_multicast(_z_sys_net_socket_t *sock, const _z_sys_net_end
+     z_result_t ret = _Z_RES_OK;
+ 
+     struct sockaddr *lsockaddr = NULL;
+-    unsigned int addrlen = 0;
++    socklen_t addrlen = 0;
+     if (rep._iptcp->ai_family == AF_INET) {
+         lsockaddr = (struct sockaddr *)z_malloc(sizeof(struct sockaddr_in));
+         if (lsockaddr != NULL) {
+@@ -516,7 +516,7 @@ z_result_t _z_listen_udp_multicast(_z_sys_net_socket_t *sock, const _z_sys_net_e
+     z_result_t ret = _Z_RES_OK;
+ 
+     struct sockaddr *lsockaddr = NULL;
+-    unsigned int addrlen = 0;
++    socklen_t addrlen = 0;
+     if (rep._iptcp->ai_family == AF_INET) {
+         lsockaddr = (struct sockaddr *)z_malloc(sizeof(struct sockaddr_in));
+         if (lsockaddr != NULL) {
+@@ -683,7 +683,7 @@ void _z_close_udp_multicast(_z_sys_net_socket_t *sockrecv, _z_sys_net_socket_t *
+ size_t _z_read_udp_multicast(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len, const _z_sys_net_endpoint_t lep,
+                              _z_slice_t *addr) {
+     struct sockaddr_storage raddr;
+-    unsigned int raddrlen = sizeof(struct sockaddr_storage);
++    socklen_t raddrlen = sizeof(struct sockaddr_storage);
+ 
+     ssize_t rb = 0;
+     do {

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,2 @@
+west==1.5.0
+eclipse-zenoh==1.9.0


### PR DESCRIPTION
Add required link-time dependencies for the `native_sim`, move global Python requirements of the project into `requirements.txt` file with pinned versions.