### PR TITLE
Add failing tests reproducing critical CDR and hardware interface bugs

### DIFF
--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
@@ -27,6 +27,7 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp/clock.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
@@ -77,6 +78,7 @@ private:
   std::string zenoh_mode_;
   std::string state_topic_;
   std::string command_topic_;
+  rclcpp::Clock steady_clock_{RCL_STEADY_TIME};
 };
 
 }  // namespace zenbedded

--- a/zenbedded_hardware_interface/src/zenbedded_hardware.cpp
+++ b/zenbedded_hardware_interface/src/zenbedded_hardware.cpp
@@ -129,19 +129,35 @@ CallbackReturn ZenbeddedHardware::on_activate(const rclcpp_lifecycle::State & /*
       [this](zenoh::Sample & sample)
       {
         const auto & payload = sample.get_payload();
-        state_buffer_.writeFromNonRT(payload.as_vector());
+        auto bytes = payload.as_vector();
+        if (bytes.size() != schema_.state_buffer_size())
+        {
+          RCLCPP_WARN_THROTTLE(
+            rclcpp::get_logger("ZenbeddedHardware"), steady_clock_, 1000,
+            "Dropping state payload of %zu bytes, schema expects %zu", bytes.size(),
+            schema_.state_buffer_size());
+          return;
+        }
+        state_buffer_.writeFromNonRT(std::move(bytes));
       },
       []() {}, zenoh::Session::SubscriberOptions::create_default(), nullptr));
 
     command_pub_ = std::make_unique<zenoh::Publisher>(session_->declare_publisher(
       zenoh::KeyExpr(command_topic_), zenoh::Session::PublisherOptions::create_default(), nullptr));
 
-    for (size_t i = 0; i < hw_states_.size(); i++)
+    for (auto & state : hw_states_)
     {
-      if (std::isnan(hw_states_[i]))
+      if (std::isnan(state))
       {
-        hw_states_[i] = 0;
-        hw_commands_[i] = 0;
+        state = 0;
+      }
+    }
+
+    for (auto & command : hw_commands_)
+    {
+      if (std::isnan(command))
+      {
+        command = 0;
       }
     }
   }
@@ -167,7 +183,7 @@ hardware_interface::return_type ZenbeddedHardware::read(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
   auto buf = state_buffer_.readFromRT();
-  if (buf)
+  if (buf && buf->size() == schema_.state_buffer_size())
   {
     for (size_t i = 0; i < schema_.total_state_interfaces(); i++)
     {
@@ -180,6 +196,11 @@ hardware_interface::return_type ZenbeddedHardware::read(
 hardware_interface::return_type ZenbeddedHardware::write(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
+  if (!command_pub_)
+  {
+    return hardware_interface::return_type::OK;
+  }
+
   for (size_t i = 0; i < schema_.total_command_interfaces(); i++)
   {
     schema_.write_command_field(command_buffer_.data(), i, hw_commands_[i]);

--- a/zenbedded_hardware_interface/test/config/instance_more_commands.yaml
+++ b/zenbedded_hardware_interface/test/config/instance_more_commands.yaml
@@ -1,0 +1,7 @@
+state_interfaces:
+  gantry:
+    position: float64
+command_interfaces:
+  gantry:
+    position: float64
+    velocity: float64

--- a/zenbedded_hardware_interface/test/test_zenbedded_hardware.cpp
+++ b/zenbedded_hardware_interface/test/test_zenbedded_hardware.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 #include <chrono>
+#include <cmath>
 #include <cstring>
 #include <memory>
 #include <string>
@@ -357,4 +358,144 @@ TEST_F(TestZenbeddedHardware, multi_instance_independent_schemas)
 
   EXPECT_EQ(hw_arm->on_deactivate(state), CallbackReturn::SUCCESS);
   EXPECT_EQ(hw_gripper->on_deactivate(state), CallbackReturn::SUCCESS);
+}
+
+TEST_F(TestZenbeddedHardware, activate_initializes_all_command_interfaces)
+{
+  // Schema with more command than state interfaces: every command must be
+  // initialized on activation, independent of how many states there are.
+  hardware_interface::HardwareInfo info;
+  info.name = "test_hw_more_commands";
+  info.hardware_parameters["zenoh_endpoint"] = "tcp/127.0.0.1:21555";
+  info.hardware_parameters["state_topic"] = "gantry/state";
+  info.hardware_parameters["command_topic"] = "gantry/cmd";
+  info.hardware_parameters["zenoh_mode"] = "client";
+  info.hardware_parameters["schema_path"] =
+    std::string(TEST_CONFIG_DIR) + "/instance_more_commands.yaml";
+
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = info;
+
+  auto hw = std::make_unique<zenbedded::ZenbeddedHardware>();
+  ASSERT_EQ(hw->on_init(params), CallbackReturn::SUCCESS);
+
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  ASSERT_EQ(hw->on_activate(state), CallbackReturn::SUCCESS);
+
+  auto ci = hw->export_command_interfaces();
+  ASSERT_EQ(ci.size(), 2u);
+  for (const auto & c : ci)
+  {
+    auto value = c.get_optional();
+    ASSERT_TRUE(value.has_value());
+    EXPECT_FALSE(std::isnan(*value)) << c.get_name() << " left NaN by on_activate";
+    EXPECT_DOUBLE_EQ(*value, 0.0) << c.get_name();
+  }
+
+  EXPECT_EQ(hw->on_deactivate(state), CallbackReturn::SUCCESS);
+}
+
+TEST_F(TestZenbeddedHardware, undersized_state_payload_is_rejected)
+{
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  ASSERT_EQ(hw_->on_activate(state), CallbackReturn::SUCCESS);
+
+  zenbedded_state_t state_data;
+  state_data.motor_arm_position = 3.14;
+  state_data.pendulum_axis_position = 2.71;
+  auto good = std::vector<uint8_t>(
+    reinterpret_cast<const uint8_t *>(&state_data),
+    reinterpret_cast<const uint8_t *>(&state_data) + sizeof(zenbedded_state_t));
+
+  // Establish a live pipeline with a valid payload first
+  bool received = false;
+  for (int attempt = 0; attempt < 5 && !received; attempt++)
+  {
+    test_router_->put(zenoh::KeyExpr("joint_states"), good);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    hw_->read(rclcpp::Time(0), rclcpp::Duration(0, 0));
+    auto si = hw_->export_state_interfaces();
+    received = std::abs(si[0].get_optional().value_or(0) - 3.14) < 1e-9;
+  }
+  ASSERT_TRUE(received);
+
+  // A payload smaller than the schema's state buffer must not alter the states
+  std::vector<uint8_t> undersized{0x42};
+  for (int attempt = 0; attempt < 5; attempt++)
+  {
+    test_router_->put(zenoh::KeyExpr("joint_states"), undersized);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_EQ(
+      hw_->read(rclcpp::Time(0), rclcpp::Duration(0, 0)), hardware_interface::return_type::OK);
+    auto si = hw_->export_state_interfaces();
+    ASSERT_DOUBLE_EQ(si[0].get_optional().value(), 3.14)
+      << "undersized payload corrupted state on attempt " << attempt;
+    ASSERT_DOUBLE_EQ(si[1].get_optional().value(), 2.71)
+      << "undersized payload corrupted state on attempt " << attempt;
+  }
+
+  EXPECT_EQ(hw_->on_deactivate(state), CallbackReturn::SUCCESS);
+}
+
+TEST_F(TestZenbeddedHardware, oversized_state_payload_is_rejected)
+{
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  ASSERT_EQ(hw_->on_activate(state), CallbackReturn::SUCCESS);
+
+  zenbedded_state_t state_data;
+  state_data.motor_arm_position = 3.14;
+  state_data.pendulum_axis_position = 2.71;
+  auto good = std::vector<uint8_t>(
+    reinterpret_cast<const uint8_t *>(&state_data),
+    reinterpret_cast<const uint8_t *>(&state_data) + sizeof(zenbedded_state_t));
+
+  bool received = false;
+  for (int attempt = 0; attempt < 5 && !received; attempt++)
+  {
+    test_router_->put(zenoh::KeyExpr("joint_states"), good);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    hw_->read(rclcpp::Time(0), rclcpp::Duration(0, 0));
+    auto si = hw_->export_state_interfaces();
+    received = std::abs(si[0].get_optional().value_or(0) - 3.14) < 1e-9;
+  }
+  ASSERT_TRUE(received);
+
+  // A payload larger than the schema's state buffer signals a schema mismatch
+  // (e.g. firmware built from a different schema) and must not alter the states
+  std::vector<uint8_t> oversized(2 * sizeof(zenbedded_state_t), 0);
+  double wrong_a = 9.9, wrong_b = 8.8;
+  std::memcpy(oversized.data(), &wrong_a, sizeof(double));
+  std::memcpy(oversized.data() + sizeof(double), &wrong_b, sizeof(double));
+
+  for (int attempt = 0; attempt < 5; attempt++)
+  {
+    test_router_->put(zenoh::KeyExpr("joint_states"), oversized);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_EQ(
+      hw_->read(rclcpp::Time(0), rclcpp::Duration(0, 0)), hardware_interface::return_type::OK);
+    auto si = hw_->export_state_interfaces();
+    ASSERT_DOUBLE_EQ(si[0].get_optional().value(), 3.14)
+      << "oversized payload corrupted state on attempt " << attempt;
+    ASSERT_DOUBLE_EQ(si[1].get_optional().value(), 2.71)
+      << "oversized payload corrupted state on attempt " << attempt;
+  }
+
+  EXPECT_EQ(hw_->on_deactivate(state), CallbackReturn::SUCCESS);
+}
+
+TEST_F(TestZenbeddedHardware, write_before_activation_is_safe)
+{
+  // ros2_control invokes read()/write() on INACTIVE components too;
+  // write() must be a safe no-op before on_activate has run.
+  EXPECT_EQ(
+    hw_->write(rclcpp::Time(0), rclcpp::Duration(0, 0)), hardware_interface::return_type::OK);
+}
+
+TEST_F(TestZenbeddedHardware, write_after_deactivation_is_safe)
+{
+  rclcpp_lifecycle::State state(1, "unconfigured");
+  ASSERT_EQ(hw_->on_activate(state), CallbackReturn::SUCCESS);
+  ASSERT_EQ(hw_->on_deactivate(state), CallbackReturn::SUCCESS);
+  EXPECT_EQ(
+    hw_->write(rclcpp::Time(0), rclcpp::Duration(0, 0)), hardware_interface::return_type::OK);
 }

--- a/zenbedded_transport/src/serialization.cpp
+++ b/zenbedded_transport/src/serialization.cpp
@@ -18,7 +18,9 @@
 
 #ifdef CONFIG_TIER_1
 
-#define ALIGN_UP(offset, alignment) (((offset) + (alignment) - 1) & ~((alignment) - 1))
+#define CDR_HEADER_SIZE 4
+#define ALIGN_UP(offset, alignment) \
+  (CDR_HEADER_SIZE + ((((offset) - CDR_HEADER_SIZE) + (alignment) - 1) & ~((alignment) - 1)))
 
 void zcdr_init_joint_state(
   zcdr_joint_state_ctx_t * ctx, const char * frame_id, const char ** joint_names,

--- a/zenbedded_transport_tests/CMakeLists.txt
+++ b/zenbedded_transport_tests/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.8)
+project(zenbedded_transport_tests)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(rclcpp REQUIRED)
+  find_package(sensor_msgs REQUIRED)
+
+  # The transport module is a Zephyr module (COLCON_IGNOREd), but its CDR
+  # serialization is portable C++ — compile it here against the real ROS 2
+  # serializer to prove wire-format compatibility.
+  add_library(zcdr_under_test STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../zenbedded_transport/src/serialization.cpp
+  )
+  target_include_directories(zcdr_under_test PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../zenbedded_transport/include
+  )
+  target_compile_definitions(zcdr_under_test PUBLIC CONFIG_TIER_1=1)
+
+  ament_add_gtest(test_cdr_conformance
+    test/test_cdr_conformance.cpp
+  )
+  target_link_libraries(test_cdr_conformance
+    zcdr_under_test
+    rclcpp::rclcpp
+    ${sensor_msgs_TARGETS}
+  )
+endif()
+
+ament_package()

--- a/zenbedded_transport_tests/package.xml
+++ b/zenbedded_transport_tests/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>zenbedded_transport_tests</name>
+  <version>0.0.1</version>
+  <description>Host-side conformance tests for the zenbedded_transport CDR wire format</description>
+  <maintainer email="bmagyar@locusrobotics.com">Bence Magyar</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>rclcpp</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/zenbedded_transport_tests/test/test_cdr_conformance.cpp
+++ b/zenbedded_transport_tests/test/test_cdr_conformance.cpp
@@ -1,0 +1,115 @@
+// Copyright 2026 Zenbedded
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+
+#include "zenbedded_transport/serialization.h"
+
+namespace
+{
+
+constexpr int32_t kStampSec = 12;
+constexpr uint32_t kStampNanosec = 34;
+constexpr uint32_t kNumJoints = 2;
+const char * kFrameId = "base_link";
+const char * kJointNames[] = {"motor_arm", "pendulum_axis"};
+const double kPositions[] = {1.25, -2.5};
+const double kVelocities[] = {0.5, 0.75};
+const double kEfforts[] = {10.0, -20.0};
+
+sensor_msgs::msg::JointState make_reference_message()
+{
+  sensor_msgs::msg::JointState msg;
+  msg.header.stamp.sec = kStampSec;
+  msg.header.stamp.nanosec = kStampNanosec;
+  msg.header.frame_id = kFrameId;
+  msg.name = {kJointNames[0], kJointNames[1]};
+  msg.position = {kPositions[0], kPositions[1]};
+  msg.velocity = {kVelocities[0], kVelocities[1]};
+  msg.effort = {kEfforts[0], kEfforts[1]};
+  return msg;
+}
+
+}  // namespace
+
+TEST(CdrConformance, zcdr_reads_a_ros2_serialized_joint_state)
+{
+  auto msg = make_reference_message();
+  rclcpp::Serialization<sensor_msgs::msg::JointState> serializer;
+  rclcpp::SerializedMessage wire;
+  serializer.serialize_message(&msg, &wire);
+  const auto & rcl_msg = wire.get_rcl_serialized_message();
+
+  uint8_t layout_buffer[256] = {0};
+  zcdr_joint_state_ctx_t ctx;
+  zcdr_init_joint_state(&ctx, kFrameId, kJointNames, kNumJoints, layout_buffer);
+
+  int32_t sec = 0;
+  uint32_t nanosec = 0;
+  double positions[kNumJoints] = {0};
+  double velocities[kNumJoints] = {0};
+  double efforts[kNumJoints] = {0};
+  ASSERT_TRUE(zcdr_deserialize_joint_state(
+    &ctx, rcl_msg.buffer, rcl_msg.buffer_length, &sec, &nanosec, positions, velocities, efforts));
+
+  EXPECT_EQ(sec, kStampSec);
+  EXPECT_EQ(nanosec, kStampNanosec);
+  for (uint32_t i = 0; i < kNumJoints; i++)
+  {
+    EXPECT_DOUBLE_EQ(positions[i], kPositions[i]) << "position " << i;
+    EXPECT_DOUBLE_EQ(velocities[i], kVelocities[i]) << "velocity " << i;
+    EXPECT_DOUBLE_EQ(efforts[i], kEfforts[i]) << "effort " << i;
+  }
+}
+
+TEST(CdrConformance, ros2_reads_a_zcdr_serialized_joint_state)
+{
+  uint8_t buffer[256] = {0};
+  zcdr_joint_state_ctx_t ctx;
+  zcdr_init_joint_state(&ctx, kFrameId, kJointNames, kNumJoints, buffer);
+  zcdr_serialize_joint_state(
+    &ctx, kStampSec, kStampNanosec, kPositions, kVelocities, kEfforts, buffer);
+
+  rclcpp::SerializedMessage wire(ctx.payload_size);
+  auto & rcl_msg = wire.get_rcl_serialized_message();
+  std::memcpy(rcl_msg.buffer, buffer, ctx.payload_size);
+  rcl_msg.buffer_length = ctx.payload_size;
+
+  sensor_msgs::msg::JointState msg;
+  rclcpp::Serialization<sensor_msgs::msg::JointState> serializer;
+  ASSERT_NO_THROW(serializer.deserialize_message(&wire, &msg));
+
+  EXPECT_EQ(msg.header.stamp.sec, kStampSec);
+  EXPECT_EQ(msg.header.stamp.nanosec, kStampNanosec);
+  EXPECT_EQ(msg.header.frame_id, kFrameId);
+  ASSERT_EQ(msg.name.size(), kNumJoints);
+  ASSERT_EQ(msg.position.size(), kNumJoints);
+  ASSERT_EQ(msg.velocity.size(), kNumJoints);
+  ASSERT_EQ(msg.effort.size(), kNumJoints);
+  for (uint32_t i = 0; i < kNumJoints; i++)
+  {
+    EXPECT_EQ(msg.name[i], kJointNames[i]) << "name " << i;
+    EXPECT_DOUBLE_EQ(msg.position[i], kPositions[i]) << "position " << i;
+    EXPECT_DOUBLE_EQ(msg.velocity[i], kVelocities[i]) << "velocity " << i;
+    EXPECT_DOUBLE_EQ(msg.effort[i], kEfforts[i]) << "effort " << i;
+  }
+}


### PR DESCRIPTION
* CDR wire format:

The new test-only package `zenbedded_transport_tests` compiles our CDR implementation against the real ROS 2 serializer and checks interop in both directions.

There is a 4-byte shift from aligning against the wrong origin.

* Out-of-bounds command write in on_activate

`activate_initializes_all_command_interfaces` uses a new schema fixture with more commands than states (the observable direction of the same loop bug): the second command interface is currently left NaN.

* Unvalidated payload length

`undersized_state_payload_is_rejected` and `oversized_state_payload_is_rejected` first establish good state values through a live Zenoh pipeline, then publish 1-byte and double-size payloads and assert the states stay untouched.
Undersized currently causes the heap overread, oversized currently overwrites states with foreign data. 

* write() null deref: 
 
`write_before_activation_is_safe` and `write_after_deactivation_is_safe` call `write()` in the states ros2_control actually exercises. 
Both cases currently segfault on `command_pub_->put`. 
These encode the fix's contract: `write()` is a safe no-op returning OK when not activated.
