### PR TITLE
add tier 2 transport demo to twister

### DIFF
--- a/demos/zenbedded_tier2_transport_test/zephyr/sample.yaml
+++ b/demos/zenbedded_tier2_transport_test/zephyr/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: Zenbedded Tier 2 Transport test
+common:
+  build_only: true
+  tags: zenbedded_transport
+tests:
+  sample.zenbedded.tier2_transport_test:
+    platform_allow:
+      - esp32s3_devkitc/esp32s3/procpu

--- a/demos/zenbedded_tier2_transport_test/zephyr/src/main.cpp
+++ b/demos/zenbedded_tier2_transport_test/zephyr/src/main.cpp
@@ -16,7 +16,7 @@
 #include <zephyr/logging/log.h>
 
 // This header MUST be generated at build-time
-#include "interface_data.h"  // NOLINT
+#include "zenbedded_transport/generated/interface_data.h"  // NOLINT
 #include "zenbedded_transport/zenoh_transport.h"
 
 LOG_MODULE_REGISTER(tier2_test, LOG_LEVEL_INF);
@@ -30,10 +30,11 @@ int main(void)
   my_state.test_motor_velocity = 0.55;
 
   // Simulate passing the raw bytes to the dumb transport pipe
-  uint8_t * raw_bytes = reinterpret_cast<uint8_t *>(&my_state);
+  const uint8_t * raw_bytes = reinterpret_cast<const uint8_t *>(&my_state);
   size_t size = sizeof(zenbedded_state_t);
 
   LOG_INF("Packed Tier 2 Struct. Total bytes to send: %zu", size);
+  LOG_HEXDUMP_INF(raw_bytes, size, "Packed Tier 2 struct");
 
   while (1)
   {


### PR DESCRIPTION
- `demos/zenbedded_tier2_transport_test` had no `sample.yaml`, so twister skipped it — the demo has never compiled since #61 while CI stayed green. It now builds on esp32s3 every run.
- Fixes what that exposed: the generated header was included by the wrong path, and an unused `raw_bytes` is fatal under warnings-as-errors.