### PR TITLE
feat: implemented TIER2

### DIFF
--- a/demos/zenbedded_test_node/prj.conf
+++ b/demos/zenbedded_test_node/prj.conf
@@ -1,29 +1,11 @@
-# ==============================================================================
-# OS Environment
-# ==============================================================================
 CONFIG_CPP=y
 CONFIG_STD_CPP17=y
 CONFIG_REQUIRES_FULL_LIBC=y
 
-# ==============================================================================
-# Zenbedded Integration
-# (Automatically injects POSIX, Networking, Zenoh-pico, and memory buffers)
-# ==============================================================================
 CONFIG_ZENBEDDED_TIER_1=y
 
-# ==============================================================================
-# Simulated RCL Configuration (To be moved to RCL Kconfig later)
-# ==============================================================================
 CONFIG_ZENBEDDED_RCL=n
-CONFIG_ZENBEDDED_RCL_DOMAIN_ID=0
-CONFIG_ZENBEDDED_RCL_NODE_NAME="Zenbedded_mcu"
-CONFIG_ZENBEDDED_RCL_ZENOH_MODE="client"
-CONFIG_ZENBEDDED_RCL_ZENOH_LOCATOR="tcp/127.0.0.1:7447"
+CONFIG_ZENBEDDED_ZENOH_IP_PORT="127.0.0.1:7447"
+CONFIG_ZENBEDDED_QOS_RELIABLE=y
 
-# ==============================================================================
-# Logging Subsystem
-# ==============================================================================
-CONFIG_LOG=y
-CONFIG_LOG_MODE_IMMEDIATE=y
-# Expose the raw Zenoh wire-traces we built in C
-CONFIG_ZENBEDDED_TRANSPORT_LOG_LEVEL=2
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000

--- a/demos/zenbedded_test_node/pytest/zenbedded_e2e_test.py
+++ b/demos/zenbedded_test_node/pytest/zenbedded_e2e_test.py
@@ -83,12 +83,16 @@ def test_ros2_commands_mcu(zenoh_router, dut: DeviceAdapter):
 
         time.sleep(0.5)
 
-        node.pub_cmd_1.publish(cmd1)
+        timer = node.create_timer(0.1, lambda: node.pub_cmd_1.publish(cmd1))
 
-        dut.readlines_until(
-            regex=r"\[SUB 1\] /joint_commands RX -> stepper: 45.00 \| pendulum: -90.50",
-            timeout=TIMEOUT_SEC,
-        )
+        try:
+            dut.readlines_until(
+                regex=r"\[SUB 1\] Rate: \d+ Hz \| stepper: 45\.00 \| pendulum: -90\.50",
+                timeout=TIMEOUT_SEC,
+            )
+        finally:
+            node.destroy_timer(timer)
+
     finally:
         rclpy.shutdown()
         executor_thread.join(timeout=1.0)

--- a/demos/zenbedded_test_node/src/main.cpp
+++ b/demos/zenbedded_test_node/src/main.cpp
@@ -8,8 +8,6 @@
 #include "zenbedded_transport/serialization.h"
 #include "zenbedded_transport/zenoh_transport.h"
 
-#ifdef CONFIG_ZENBEDDED_TIER_1
-
 // 1. Define global context so the callback knows how to parse the incoming bytes
 zcdr_joint_command_ctx_t ctx_sub_1;
 
@@ -19,12 +17,33 @@ void cmd_1_rx_callback(const uint8_t * payload, size_t size, void * user_data)
   zcdr_joint_command_ctx_t * ctx = reinterpret_cast<zcdr_joint_command_ctx_t *>(user_data);
   double vals[2] = {0};
 
-  if (zcdr_deserialize_joint_command(ctx, payload, size, NULL, NULL, vals))
+  static uint32_t rx_count = 0;
+  static uint32_t last_hz_time = 0;
+
+  rx_count++;
+  uint32_t current_time = k_uptime_get_32();
+
+  if (last_hz_time == 0)
   {
-    printf("[SUB 1] /joint_commands RX -> stepper: %.2f | pendulum: %.2f\n", vals[0], vals[1]);
+    last_hz_time = current_time;
+  }
+
+  bool success = zcdr_deserialize_joint_command(ctx, payload, size, NULL, NULL, vals);
+
+  if ((current_time - last_hz_time) >= 1000)
+  {
+    if (success)
+    {
+      printf("[SUB 1] Rate: %u Hz | stepper: %.2f | pendulum: %.2f\n", rx_count, vals[0], vals[1]);
+    }
+    else
+    {
+      printf("[SUB 1] Rate: %u Hz | ERROR: Deserialization failed (size: %zu)\n", rx_count, size);
+    }
+    rx_count = 0;
+    last_hz_time = current_time;
   }
 }
-#endif  // CONFIG_ZENBEDDED_TIER_1
 
 int main(void)
 {
@@ -35,13 +54,11 @@ int main(void)
 
 #ifdef CONFIG_ZENBEDDED_TIER_1
 
-  // Read from the Kconfig environment
-  int domain_id = CONFIG_ZENBEDDED_RCL_DOMAIN_ID;
-  const char * node_name = CONFIG_ZENBEDDED_RCL_NODE_NAME;
-  const char * mode = CONFIG_ZENBEDDED_RCL_ZENOH_MODE;
-  const char * locator = CONFIG_ZENBEDDED_RCL_ZENOH_LOCATOR;
-
-  if (zenbedded_transport_init(domain_id, node_name, mode, locator) != 0)
+  // Pass Kconfig macros directly into the transport API
+  if (
+    zenbedded_transport_init(
+      CONFIG_ZENBEDDED_DOMAIN_ID, CONFIG_ZENBEDDED_NODE_NAME, CONFIG_ZENBEDDED_ZENOH_MODE,
+      CONFIG_ZENBEDDED_ZENOH_IP_PORT) != 0)
   {
     printf("[FATAL] Transport init failed!\n");
     return -1;
@@ -53,7 +70,7 @@ int main(void)
   zcdr_joint_state_ctx_t ctx_joints;
   uint8_t buf_joints[512] = {0};
 
-  // We need a dummy buffer to initialize the read offset for the subscriber
+  // Dummy buffer to initialize the read offset for the subscriber
   uint8_t dummy_1[256] = {0};
 
   zcdr_init_joint_state(&ctx_joints, "base_link", chassis_joints, 2, buf_joints);
@@ -62,12 +79,12 @@ int main(void)
   // --- PUBLISHER DECLARATION ---
   zenbedded_pub_t pub_joints =
     zenbedded_transport_declare_publisher("joint_states", "sensor_msgs::msg::dds_::JointState_");
-  k_msleep(10);  // Prevent router UDP saturation
+  k_msleep(10);  // Pace graph declarations
 
   // --- SUBSCRIBER DECLARATION ---
   zenbedded_transport_declare_subscriber(
     "joint_commands", "control_msgs::msg::dds_::JointCommand_", cmd_1_rx_callback, &ctx_sub_1);
-  k_msleep(10);  // Prevent router UDP saturation
+  k_msleep(10);  // Pace graph declarations
 
   // --- DATA PAYLOADS ---
   double pos_2[] = {0.0, 0.0};
@@ -75,24 +92,21 @@ int main(void)
   double eff_2[] = {0.0, 0.0};
 
   // --- TIMING SETUP ---
-  uint32_t last_50hz_time = k_uptime_get_32();
+  uint32_t last_100hz_time = k_uptime_get_32();
 
   printf("\n[SYS] Entering High-Frequency Event Loop...\n\n");
 
   while (1)
   {
-    // 1. DRAIN NETWORK & KEEPALIVE (This triggers the callbacks!)
-    zenbedded_transport_spin();
-
     uint32_t current_time = k_uptime_get_32();
 
-    // 2. PUB 1: 50Hz LOOP (Every 20 ms)
-    if ((current_time - last_50hz_time) >= 20)
+    // 2. PUB 1: 100Hz LOOP (Every 10 ms)
+    if ((current_time - last_100hz_time) >= 10)
     {
       zcdr_serialize_joint_state(&ctx_joints, 0, 0, pos_2, vel_2, eff_2, buf_joints);
       zenbedded_transport_publish(pub_joints, buf_joints, ctx_joints.payload_size);
       pos_2[0] += 0.01;
-      last_50hz_time = current_time;
+      last_100hz_time = current_time;
     }
 
     // Yield CPU for 1ms to prevent starvation on native_sim

--- a/demos/zenbedded_tier2_transport_test/ros2/tests/test.py
+++ b/demos/zenbedded_tier2_transport_test/ros2/tests/test.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import zenoh
+import struct
+import time
+import threading
+
+# --- THREAD SYNCHRONIZATION ---
+pong_received = threading.Event()
+latest_state = (0.0, 0.0)
+
+# --- DEBUG COUNTERS ---
+total_callbacks_received = 0
+last_callback_timestamp = 0.0
+
+
+def state_callback(sample):
+    global latest_state, total_callbacks_received, last_callback_timestamp
+    try:
+        payload_bytes = bytes(sample.payload)
+        latest_state = struct.unpack("<dd", payload_bytes)
+
+        total_callbacks_received += 1
+        last_callback_timestamp = time.perf_counter()
+
+        pong_received.set()
+
+    except struct.error:
+        pass
+
+
+if __name__ == "__main__":
+    conf = zenoh.Config()
+    conf.insert_json5("mode", '"peer"')
+    conf.insert_json5("listen/endpoints", '["udp/0.0.0.0:7447"]')
+
+    print("[INFO] Zenbedded Tier 2 Ping-Pong Benchmark Server")
+    z = zenoh.open(conf)
+
+    pub = z.declare_publisher("test_motor/cmd")
+    sub = z.declare_subscriber("test_motor/state", state_callback)
+
+    try:
+        effort = 0.0
+        ping_count = 0
+        total_rtt = 0.0
+        consecutive_timeouts = 0
+        last_report_time = time.time()
+
+        print("\n[INFO] Sending initial command frame....")
+        pong_received.clear()
+        start_rtt = time.perf_counter()
+        pub.put(struct.pack("<d", effort))
+        effort += 0.1
+
+        while True:
+            wait_entry_time = time.perf_counter()
+
+            if pong_received.wait(timeout=1.0):
+                end_rtt = time.perf_counter()
+                consecutive_timeouts = 0
+
+                rtt = end_rtt - start_rtt
+                total_rtt += rtt
+                ping_count += 1
+
+                pong_received.clear()
+
+                start_rtt = time.perf_counter()
+                pub.put(struct.pack("<d", effort))
+                effort += 0.1
+
+            else:
+                wait_exit_time = time.perf_counter()
+                consecutive_timeouts += 1
+                actual_wait_duration_ms = (wait_exit_time - wait_entry_time) * 1000
+
+                time_since_last_packet_ms = (
+                    (wait_exit_time - last_callback_timestamp) * 1000
+                    if last_callback_timestamp > 0
+                    else float("inf")
+                )
+
+                print(f"\n [STALL DETECTED] Timeout Event #{consecutive_timeouts} Triggered!")
+                print(
+                    f"   ├─ Spent precisely {actual_wait_duration_ms:.3f}ms waiting inside the lock."
+                )
+                print(
+                    f"   ├─ Time since the last data packet actually reached the host callback: {time_since_last_packet_ms:.3f}ms"
+                )
+                print(
+                    f"   ├─ Current tracked position state register inside memory context: {latest_state[0]:.2f}"
+                )
+                print(
+                    f"   └─ Total standalone packet frames handled by Python callback since boot: {total_callbacks_received}"
+                )
+
+                # RECOVERY / RESYNC PHASE
+                print(
+                    "   [RECOVERY] Injecting a fresh asynchronous command frame to kick-start loop alignment..."
+                )
+                pong_received.clear()
+                start_rtt = time.perf_counter()
+                pub.put(struct.pack("<d", effort))
+                effort += 0.1
+
+                time.sleep(0.1)
+                continue
+
+            current_time = time.time()
+            elapsed = current_time - last_report_time
+
+            if elapsed >= 1.0:
+                closed_loop_hz = ping_count / elapsed
+                avg_rtt_ms = (total_rtt / ping_count) * 1000 if ping_count > 0 else 0
+                pos, vel = latest_state
+
+                print(
+                    f"[METRIC] Sync Speed: {closed_loop_hz:.2f} Hz | Avg Latency (RTT): {avg_rtt_ms:.3f} ms | Pos: {pos:.2f} | Total Frames: {total_callbacks_received}"
+                )
+
+                ping_count = 0
+                total_rtt = 0.0
+                last_report_time = current_time
+
+    except KeyboardInterrupt:
+        print("\nShutting down Host Peer.")
+    finally:
+        z.close()

--- a/demos/zenbedded_tier2_transport_test/zephyr/boards/esp32s3_devkitc_esp32s3_procpu.conf
+++ b/demos/zenbedded_tier2_transport_test/zephyr/boards/esp32s3_devkitc_esp32s3_procpu.conf
@@ -1,0 +1,7 @@
+# boards/esp32s3_devkitc_esp32s3_procpu.conf
+# Extra Kconfig applied only when building for ESP32-S3
+
+CONFIG_GLIBCXX_LIBCPP=y
+CONFIG_POSIX_API=y
+CONFIG_NEWLIB_LIBC=y
+CONFIG_NEWLIB_LIBC_NANO=n

--- a/demos/zenbedded_tier2_transport_test/zephyr/boards/native_sim_native_64.conf
+++ b/demos/zenbedded_tier2_transport_test/zephyr/boards/native_sim_native_64.conf
@@ -1,0 +1,8 @@
+CONFIG_ETH_NATIVE_TAP=n
+CONFIG_NET_DRIVERS=y
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_SOCKETS_OFFLOAD=y
+CONFIG_NET_NATIVE_OFFLOADED_SOCKETS=y
+
+# IPv6 DAD requires lower level network interface access, below exposed socket-level access
+CONFIG_NET_IPV6_DAD=n

--- a/demos/zenbedded_tier2_transport_test/zephyr/prj.conf
+++ b/demos/zenbedded_tier2_transport_test/zephyr/prj.conf
@@ -2,12 +2,16 @@ CONFIG_CPP=y
 CONFIG_STD_CPP17=y
 CONFIG_REQUIRES_FULL_LIBC=y
 
-# Enable Tier 2 (Raw Structs) instead of Tier 1 (ZCDR)
 CONFIG_ZENBEDDED_TIER_2=y
 
-# Optional for this demo as its in the right default path, only use this if the user wants a different path
 CONFIG_ZENBEDDED_TIER2_SCHEMA_PATH="config/interface_schema.yaml"
+
+CONFIG_ZENBEDDED_ZENOH_IP_PORT="127.0.0.1:7447"
+
+CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_LOG=y
 CONFIG_LOG_MODE_IMMEDIATE=y
 CONFIG_ZENBEDDED_TRANSPORT_LOG_LEVEL=3
+
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000

--- a/demos/zenbedded_tier2_transport_test/zephyr/src/main.cpp
+++ b/demos/zenbedded_tier2_transport_test/zephyr/src/main.cpp
@@ -1,44 +1,107 @@
-// Copyright 2026 Open Source Robotics Foundation, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2026 Zenbedded
+// Licensed under the Apache License, Version 2.0
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
-// This header MUST be generated at build-time
-#include "zenbedded_transport/generated/interface_data.h"  // NOLINT
+#include "zenbedded_transport/generated/interface_data.h"
 #include "zenbedded_transport/zenoh_transport.h"
 
 LOG_MODULE_REGISTER(tier2_test, LOG_LEVEL_INF);
 
-int main(void)
+// --- GLOBAL HANDLES ---
+static zenbedded_pub_t g_state_pub = NULL;
+static zenbedded_sub_t g_cmd_sub = NULL;
+
+// --- LOCK-FREE BUFFERING ---
+static zenbedded_command_t g_latest_cmd = {0};
+static zenbedded_state_t g_current_state = {0};
+
+// --- RTOS SCHEDULING ---
+K_SEM_DEFINE(g_control_sem, 0, 1);
+
+// --- CALLBACK: NETWORK -> APP ---
+static void on_command_received(const uint8_t * payload, size_t size, void * user_data)
 {
-  LOG_INF("Starting Zenbedded Tier 2 Transport Test");
+  (void)user_data;
+  if (size != sizeof(zenbedded_command_t))
+  {
+    LOG_WRN("Payload size mismatch. Expected %zu, got %zu", sizeof(zenbedded_command_t), size);
+    return;
+  }
 
-  zenbedded_state_t my_state;
-  my_state.test_motor_position = 1.23;
-  my_state.test_motor_velocity = 0.55;
+  memcpy(&g_latest_cmd, payload, sizeof(zenbedded_command_t));
 
-  // Simulate passing the raw bytes to the dumb transport pipe
-  const uint8_t * raw_bytes = reinterpret_cast<const uint8_t *>(&my_state);
-  size_t size = sizeof(zenbedded_state_t);
+  k_sem_give(&g_control_sem);
+}
+// --- THREAD 2: MOTOR CONTROL LOOP (Event Driven) ---
+static void motor_control_thread(void *, void *, void *)
+{
+  LOG_INF("Motor control thread initialized. Waiting for Host commands...");
 
-  LOG_INF("Packed Tier 2 Struct. Total bytes to send: %zu", size);
-  LOG_HEXDUMP_INF(raw_bytes, size, "Packed Tier 2 struct");
+  uint32_t loop_counter = 0;
 
   while (1)
   {
-    k_sleep(K_MSEC(1000));
+    // Sleep until the network callback gives the semaphore
+    k_sem_take(&g_control_sem, K_FOREVER);
+
+    g_current_state.test_motor_position += 0.01;
+    g_current_state.test_motor_velocity = g_latest_cmd.test_motor_effort * 0.5;
+
+    if (g_state_pub)
+    {
+      zenbedded_transport_publish(
+        g_state_pub, reinterpret_cast<const uint8_t *>(&g_current_state),
+        sizeof(zenbedded_state_t));
+    }
+
+    loop_counter++;
+    if (loop_counter % 1000 == 0)
+    {
+      LOG_INF(
+        "Processed 1000 Commands | Pos: %.2f | Last Eff: %.2f", g_current_state.test_motor_position,
+        g_latest_cmd.test_motor_effort);
+    }
+  }
+}
+K_THREAD_DEFINE(ctrl_tid, 4096, motor_control_thread, NULL, NULL, NULL, K_PRIO_PREEMPT(1), 0, 0);
+
+// --- MAIN SETUP ---
+int main(void)
+{
+  LOG_INF("--- Zenbedded Tier 2 Ping-Pong Node ---");
+
+  if (
+    zenbedded_transport_init(
+      0, "mcu", CONFIG_ZENBEDDED_ZENOH_MODE, CONFIG_ZENBEDDED_ZENOH_IP_PORT) != 0)
+  {
+    LOG_ERR("Failed to initialize transport");
+    return -1;
+  }
+
+  k_sleep(K_MSEC(500));
+
+  g_state_pub = zenbedded_transport_declare_publisher("test_motor/state", NULL);
+  if (!g_state_pub)
+  {
+    LOG_ERR("Failed to declare publisher");
+    return -1;
+  }
+
+  g_cmd_sub =
+    zenbedded_transport_declare_subscriber("test_motor/cmd", NULL, on_command_received, NULL);
+  if (!g_cmd_sub)
+  {
+    LOG_ERR("Failed to declare subscriber");
+    return -1;
+  }
+
+  LOG_INF("Pipes created. RTOS threads take over from here.");
+
+  while (1)
+  {
+    k_sleep(K_FOREVER);
   }
   return 0;
 }

--- a/zenbedded_transport/CMakeLists.txt
+++ b/zenbedded_transport/CMakeLists.txt
@@ -6,6 +6,10 @@ zephyr_include_directories(include)
 zephyr_library_sources(src/zenoh_transport.c)
 zephyr_library_compile_definitions(Z_CONFIG_SOCKET_TIMEOUT=1)
 
+zephyr_compile_definitions(
+  Z_FEATURE_UNSTABLE_API=1
+)
+
 if(CONFIG_ZENBEDDED_TIER_1)
   zephyr_library_sources(src/serialization.c)
 endif()

--- a/zenbedded_transport/Kconfig
+++ b/zenbedded_transport/Kconfig
@@ -22,6 +22,7 @@ config ZENBEDDED_TIER_1
     select POSIX_API
     select CBPRINTF_FP_SUPPORT
     select ZENOH_PICO
+    select ZENOH_PICO_MULTI_THREAD
     select ZENOH_PICO_LINK_UDP_UNICAST
     select ZENOH_PICO_LINK_TCP
     select ZENOH_PICO_PUBLICATION
@@ -33,12 +34,10 @@ config ZENBEDDED_TIER_2
     bool "Tier 2: High-Throughput Raw Numeric"
     select NETWORKING
     select NET_IPV4
-    select NET_UDP
-    select NET_TCP
     select NET_SOCKETS
     select POSIX_API
     select ZENOH_PICO
-    select ZENOH_PICO_LINK_TCP
+    select ZENOH_PICO_MULTI_THREAD
     select ZENOH_PICO_PUBLICATION
     select ZENOH_PICO_SUBSCRIPTION
 
@@ -46,6 +45,81 @@ config ZENBEDDED_TIER_3
     bool "Tier 3: Bit-Optimal Packed"
 
 endchoice
+
+# ==============================================================================
+# ZENOH MODE & NETWORK CONFIG
+# ==============================================================================
+
+choice ZENBEDDED_MODE
+    prompt "Zenoh Node Mode"
+    default ZENBEDDED_MODE_CLIENT
+
+config ZENBEDDED_MODE_CLIENT
+    bool "Client Mode (Default, Lightweight)"
+    help
+      The MCU connects to a listening Host PC (Peer) or Router.
+      This is the fastest, lowest-RAM option. Highly recommended.
+
+config ZENBEDDED_MODE_PEER
+    bool "Peer Mode (Listener / P2P)"
+    help
+      The MCU acts as a Peer (Listener/Router).
+      WARNING: Requires more RAM for routing tables.
+
+endchoice
+
+config ZENBEDDED_ZENOH_MODE
+    string
+    default "client" if ZENBEDDED_MODE_CLIENT
+    default "peer" if ZENBEDDED_MODE_PEER
+
+choice ZENBEDDED_RELIABILITY
+    prompt "Tier 2 Transport Protocol"
+    default ZENBEDDED_QOS_BEST_EFFORT
+
+config ZENBEDDED_QOS_BEST_EFFORT
+    bool "Best Effort (UDP)"
+    select NET_UDP
+    select ZENOH_PICO_LINK_UDP_UNICAST if ZENBEDDED_MODE_CLIENT
+    select ZENOH_PICO_LINK_UDP_MULTICAST if ZENBEDDED_MODE_PEER
+    help
+      Uses UDP transport.
+      If Client: Uses UDP Unicast.
+      If Peer: Uses UDP Multicast.
+      Note: Default enforces Zenoh Best-Effort & Congestion Drop.
+
+config ZENBEDDED_QOS_RELIABLE
+    bool "Reliable (TCP)"
+    select NET_TCP
+    select ZENOH_PICO_LINK_TCP
+    help
+      Uses TCP transport.
+      Valid for both Client (Unicast) and Peer (P2P Unicast).
+      Provides OS-level retries. Default enforces Congestion Drop to protect 500Hz loops.
+
+endchoice
+
+config ZENBEDDED_ZENOH_IP_PORT
+    string "Zenoh Target (IP:Port)"
+    default "127.0.0.1:7447"
+    help
+      For Client: Enter Host PC IP (e.g., 192.168.1.50:7447).
+      For TCP Peer: Enter Listener IP (e.g., 0.0.0.0:7447).
+      For UDP Peer: Enter Multicast IP (e.g., 224.0.0.123:7447).
+      The transport layer will automatically prepend "udp/" or "tcp/".
+
+config ZENBEDDED_DOMAIN_ID
+    int "ROS 2 Domain ID"
+    default 0
+    help
+      The network domain ID. Must match the Host PC's ROS_DOMAIN_ID.
+      Isolates different robot systems on the same network.
+
+config ZENBEDDED_NODE_NAME
+    string "Zenbedded Node Name"
+    default "zenbedded_node"
+    help
+      The unique identifier for this specific microcontroller on the network.
 
 # ==============================================================================
 # TIER 2 CONFIGURATION
@@ -58,13 +132,10 @@ config ZENBEDDED_TIER2_SCHEMA_PATH
     help
       Path to the YAML schema file relative to the application's source directory.
       The build system will read this file to auto-generate the C-header struct.
-      Fallback default is interface_schema.yaml in the app root.
 
 # ==============================================================================
 # SYSTEM DEFAULTS
 # ==============================================================================
-
-if ZENBEDDED_TIER_1
 
 config NET_BUF_DATA_SIZE
     default 256
@@ -89,7 +160,5 @@ config MAIN_STACK_SIZE
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
     default 8192
-
-endif # ZENBEDDED_TIER_1
 
 endmenu

--- a/zenbedded_transport/include/zenbedded_transport/zenoh_transport.h
+++ b/zenbedded_transport/include/zenbedded_transport/zenoh_transport.h
@@ -14,10 +14,12 @@ extern "C"
 
   /**
    * @brief Initializes the Zenbedded transport engine.
-   * @param domain_id The ROS 2 Domain ID.
-   * @param node_name The ROS 2 Node Name (appears in 'ros2 node list').
+   *
+   * @param domain_id ROS 2 Domain ID (Tier 1). Ignored in Tier 2.
+   * @param node_name ROS 2 Node Name (Tier 1). Ignored in Tier 2.
    * @param mode "client" or "peer".
-   * @param locator The endpoint (e.g., "tcp/192.168.1.100:7447").
+   * @param locator Network endpoint (IP:PORT, e.g., "127.0.0.1:7447"). The transport layer
+   * automatically prepends the protocol.
    * @return 0 on success, -1 on failure.
    */
   int zenbedded_transport_init(
@@ -29,35 +31,28 @@ extern "C"
   void zenbedded_transport_destroy(void);
 
   /**
-   * @brief Deterministic network polling executor.
-   *
-   * Must be called continuously by the application's event loop to drain
-   * inbound sockets and maintain keep-alive heartbeats without OS thread blocking.
+   @deprecated Network I/O is now handled autonomously by Zenoh-Pico background tasks
    */
   void zenbedded_transport_spin(void);
 
-#ifdef CONFIG_ZENBEDDED_TIER_1
-
-  // Opaque handles. The user/RCL cannot see inside these structs.
   typedef struct zenbedded_pub_s * zenbedded_pub_t;
   typedef struct zenbedded_sub_s * zenbedded_sub_t;
 
   /**
-   * @brief Declares a native ROS 2 Publisher on the graph.
+   * @brief Declares a Publisher on the graph.
    *
-   * @param topic_name The ROS 2 topic name (e.g., "joint_states").
-   * @param type_name The DDS type namespace (e.g., "sensor_msgs::msg::dds_::JointState_").
-   * @param type_hash The 64-character cryptographic type hash.
-   * @return Opaque handle to the publisher pool entry, or NULL on failure.
+   * @param topic_name The exact topic name (e.g., "joint_states" or "arm/state").
+   * @param type_name DDS type namespace (Tier 1). Pass NULL for Tier 2 custom payloads.
+   * @return Opaque handle, or NULL on failure.
    */
   zenbedded_pub_t zenbedded_transport_declare_publisher(
     const char * topic_name, const char * type_name);
 
   /**
-   * @brief Pushes a serialized CDR payload over the Zenoh transport.
+   * @brief Pushes a payload over the Zenoh transport.
    *
    * @param pub The publisher handle.
-   * @param payload Pointer to the CDR serialized byte buffer.
+   * @param payload Pointer to the CDR buffer (Tier 1) or raw struct memory (Tier 2).
    * @param payload_size Length of the payload in bytes.
    * @return 0 on success, negative error code on failure.
    */
@@ -70,20 +65,17 @@ extern "C"
   typedef void (*zenbedded_recv_cb_t)(const uint8_t * payload, size_t size, void * user_data);
 
   /**
-   * @brief Declares a native ROS 2 Subscriber on the graph.
+   * @brief Declares a Subscriber on the graph.
    *
-   * @param topic_name The ROS 2 topic name.
-   * @param type_name The DDS type namespace.
-   * @param type_hash The 64-character cryptographic type hash.
-   * @param callback Function invoked when a message is received.
+   * @param topic_name The exact topic name (e.g., "joint_commands" or "arm/cmd").
+   * @param type_name DDS type namespace (Tier 1). Pass NULL for Tier 2 custom payloads.
+   * @param callback Function invoked when a network payload is received.
    * @param user_data Arbitrary data passed back to the callback context.
-   * @return Opaque handle to the subscriber pool entry, or NULL on failure.
+   * @return Opaque handle, or NULL on failure.
    */
   zenbedded_sub_t zenbedded_transport_declare_subscriber(
     const char * topic_name, const char * type_name, zenbedded_recv_cb_t callback,
     void * user_data);
-
-#endif  // CONFIG_ZENBEDDED_TIER_1
 
 #ifdef __cplusplus
 }

--- a/zenbedded_transport/src/zenoh_transport.c
+++ b/zenbedded_transport/src/zenoh_transport.c
@@ -21,16 +21,13 @@ static z_owned_session_t z_session;
 static uint32_t current_domain_id = 0;
 static char current_node_name[64] = {0};
 static bool is_initialized = false;
-static uint32_t last_keepalive_time_ms = 0;
 
-#define KEEPALIVE_INTERVAL_MS 5000
-
-#ifdef CONFIG_ZENBEDDED_TIER_1
 #define MAX_PUBLISHERS 10
 #define MAX_SUBSCRIBERS 10
 #define KEYEXPR_MAX_LEN 512
 #define RMW_GID_SIZE 16
 
+#if defined(CONFIG_ZENBEDDED_TIER_1)
 typedef struct __attribute__((packed))
 {
   int64_t sequence_number;
@@ -38,15 +35,18 @@ typedef struct __attribute__((packed))
   uint8_t gid_length;
   uint8_t gid[RMW_GID_SIZE];
 } rmw_zenoh_attachment_t;
+#endif
 
 struct zenbedded_pub_s
 {
   bool in_use;
   z_owned_publisher_t z_pub;
-  rmw_zenoh_attachment_t attachment;
   char topic_keyexpr[KEYEXPR_MAX_LEN];
+#if defined(CONFIG_ZENBEDDED_TIER_1)
+  rmw_zenoh_attachment_t attachment;
   z_owned_liveliness_token_t lv_token;
   char lv_keyexpr[KEYEXPR_MAX_LEN];
+#endif
 };
 
 struct zenbedded_sub_s
@@ -56,15 +56,19 @@ struct zenbedded_sub_s
   zenbedded_recv_cb_t user_cb;
   void * user_data;
   char topic_keyexpr[KEYEXPR_MAX_LEN];
+#if defined(CONFIG_ZENBEDDED_TIER_1)
   z_owned_liveliness_token_t lv_token;
   char lv_keyexpr[KEYEXPR_MAX_LEN];
+#endif
 };
 
 static struct zenbedded_pub_s pub_pool[MAX_PUBLISHERS] = {0};
 static struct zenbedded_sub_s sub_pool[MAX_SUBSCRIBERS] = {0};
 
+#if defined(CONFIG_ZENBEDDED_TIER_1)
 static z_owned_liveliness_token_t node_lv_token;
 static char node_lv_str[KEYEXPR_MAX_LEN] = {0};
+#endif
 
 static void internal_sub_handler(z_loaned_sample_t * sample, void * arg)
 {
@@ -74,19 +78,38 @@ static void internal_sub_handler(z_loaned_sample_t * sample, void * arg)
     return;
   }
 
-  z_bytes_reader_t reader = z_bytes_get_reader(z_sample_payload(sample));
-  size_t len = z_bytes_len(z_sample_payload(sample));
+  const z_loaned_bytes_t * payload = z_sample_payload(sample);
+  size_t len = z_bytes_len(payload);
 
-  static uint8_t rx_buf[1024];
-  if (len > sizeof(rx_buf))
+#if defined(CONFIG_ZENBEDDED_TIER_1)
+  uint8_t rx_buf[1024];
+  if (len == 0 || len > sizeof(rx_buf))
   {
-    LOG_WRN("Incoming payload too large (%zu bytes), dropping.", len);
     return;
   }
+
+  z_bytes_reader_t reader = z_bytes_get_reader(payload);
   z_bytes_reader_read(&reader, rx_buf, len);
   sub->user_cb(rx_buf, len, sub->user_data);
+
+#elif defined(CONFIG_ZENBEDDED_TIER_2)
+#define T2_MAX_BUFFER_BOUND 64
+
+  if (len == 0 || len > T2_MAX_BUFFER_BOUND)
+  {
+    return;
+  }
+
+  uint8_t t2_rx_buf[T2_MAX_BUFFER_BOUND];
+
+  z_bytes_reader_t reader = z_bytes_get_reader(payload);
+  z_bytes_reader_read(&reader, t2_rx_buf, len);
+
+  sub->user_cb(t2_rx_buf, len, sub->user_data);
+
+#undef T2_MAX_BUFFER_BOUND
+#endif
 }
-#endif  // CONFIG_ZENBEDDED_TIER_1
 
 int zenbedded_transport_init(
   uint32_t domain_id, const char * node_name, const char * mode, const char * locator)
@@ -103,17 +126,41 @@ int zenbedded_transport_init(
   z_config_default(&z_config);
   zp_config_insert(z_config_loan_mut(&z_config), Z_CONFIG_MODE_KEY, mode);
 
+  static char full_locator[128];
+
   if (locator && strlen(locator) > 0)
   {
-    uint8_t key = (strcmp(mode, "client") == 0) ? Z_CONFIG_CONNECT_KEY : Z_CONFIG_LISTEN_KEY;
-    zp_config_insert(z_config_loan_mut(&z_config), key, locator);
+#if defined(CONFIG_ZENBEDDED_QOS_RELIABLE)
+    snprintf(full_locator, sizeof(full_locator), "tcp/%s", locator);
+#else
+    snprintf(full_locator, sizeof(full_locator), "udp/%s", locator);
+#endif
+
+#if defined(CONFIG_ZENBEDDED_MODE_CLIENT)
+    uint8_t key = Z_CONFIG_CONNECT_KEY;
+#else
+    uint8_t key = Z_CONFIG_LISTEN_KEY;
+#endif
+
+    zp_config_insert(z_config_loan_mut(&z_config), key, full_locator);
+
+    LOG_INF("Transport Locator mapped to: %s (Key: %d)", full_locator, key);
   }
 
-  if (z_open(&z_session, z_config_move(&z_config), NULL) != Z_OK)
+  if (z_open(&z_session, z_move(z_config), NULL) != Z_OK)
   {
-    LOG_ERR("Failed to open Zenoh session");
+    LOG_ERR("Failed to open Zenoh session!");
     return -1;
   }
+  LOG_INF("Zenoh session opened successfully");
+
+  zp_task_read_options_t read_opts;
+  zp_task_read_options_default(&read_opts);
+  zp_start_read_task(z_session_loan_mut(&z_session), &read_opts);
+
+  zp_task_lease_options_t lease_opts;
+  zp_task_lease_options_default(&lease_opts);
+  zp_start_lease_task(z_session_loan_mut(&z_session), &lease_opts);
 
 #ifdef CONFIG_ZENBEDDED_TIER_1
   z_id_t zid = z_info_zid(z_session_loan(&z_session));
@@ -134,7 +181,6 @@ int zenbedded_transport_init(
     z_session_loan(&z_session), &node_lv_token, z_view_keyexpr_loan(&ke), NULL);
 #endif
 
-  last_keepalive_time_ms = k_uptime_get_32();
   is_initialized = true;
   LOG_INF("Transport Initialized on Domain %u (Node: %s)", domain_id, current_node_name);
   return 0;
@@ -147,12 +193,13 @@ void zenbedded_transport_destroy(void)
     return;
   }
 
-#ifdef CONFIG_ZENBEDDED_TIER_1
   for (int i = 0; i < MAX_PUBLISHERS; i++)
   {
     if (pub_pool[i].in_use)
     {
+#if defined(CONFIG_ZENBEDDED_TIER_1)
       z_liveliness_undeclare_token(z_move(pub_pool[i].lv_token));
+#endif
       z_undeclare_publisher(z_publisher_move(&pub_pool[i].z_pub));
       pub_pool[i].in_use = false;
     }
@@ -161,12 +208,20 @@ void zenbedded_transport_destroy(void)
   {
     if (sub_pool[i].in_use)
     {
+#if defined(CONFIG_ZENBEDDED_TIER_1)
+      z_liveliness_undeclare_token(z_move(sub_pool[i].lv_token));
+#endif
       z_undeclare_subscriber(z_subscriber_move(&sub_pool[i].z_sub));
       sub_pool[i].in_use = false;
     }
   }
+
+#if defined(CONFIG_ZENBEDDED_TIER_1)
   z_liveliness_undeclare_token(z_move(node_lv_token));
 #endif
+
+  zp_stop_read_task(z_session_loan_mut(&z_session));
+  zp_stop_lease_task(z_session_loan_mut(&z_session));
 
   z_close(z_session_loan_mut(&z_session), NULL);
   is_initialized = false;
@@ -175,27 +230,9 @@ void zenbedded_transport_destroy(void)
 
 void zenbedded_transport_spin(void)
 {
-  if (!is_initialized)
-  {
-    return;
-  }
-
-  zp_read_options_t read_opts;
-  zp_read_options_default(&read_opts);
-  zp_read(z_session_loan(&z_session), &read_opts);
-
-  uint32_t now = k_uptime_get_32();
-  if ((now - last_keepalive_time_ms) >= KEEPALIVE_INTERVAL_MS)
-  {
-    LOG_DBG("[HEARTBEAT] Transmitting KeepAlive pulse (Uptime: %u ms)", now);
-    zp_send_keep_alive_options_t ka_opts;
-    zp_send_keep_alive_options_default(&ka_opts);
-    zp_send_keep_alive(z_session_loan(&z_session), &ka_opts);
-    last_keepalive_time_ms = now;
-  }
+  // Deprecated: Network I/O handled autonomously by Zenoh-Pico background tasks
 }
 
-#ifdef CONFIG_ZENBEDDED_TIER_1
 zenbedded_pub_t zenbedded_transport_declare_publisher(
   const char * topic_name, const char * type_name)
 {
@@ -203,8 +240,6 @@ zenbedded_pub_t zenbedded_transport_declare_publisher(
   {
     return NULL;
   }
-
-  const char * type_hash = zenbedded_get_rihs_hash(type_name);
 
   struct zenbedded_pub_s * pub = NULL;
   for (int i = 0; i < MAX_PUBLISHERS; i++)
@@ -223,12 +258,13 @@ zenbedded_pub_t zenbedded_transport_declare_publisher(
   }
 
   const char * clean_topic = (topic_name[0] == '/') ? topic_name + 1 : topic_name;
+  z_view_keyexpr_t ke;
 
+#if defined(CONFIG_ZENBEDDED_TIER_1)
+  const char * type_hash = zenbedded_get_rihs_hash(type_name);
   snprintf(
     pub->topic_keyexpr, KEYEXPR_MAX_LEN, "%u/%s/%s/%s", current_domain_id, clean_topic, type_name,
     type_hash);
-
-  z_view_keyexpr_t ke;
   z_view_keyexpr_from_str_unchecked(&ke, pub->topic_keyexpr);
 
   if (
@@ -236,10 +272,28 @@ zenbedded_pub_t zenbedded_transport_declare_publisher(
     Z_OK)
   {
     pub->in_use = false;
-    LOG_ERR("Failed to declare Zenoh publisher for %s", pub->topic_keyexpr);
     return NULL;
   }
+#elif defined(CONFIG_ZENBEDDED_TIER_2)
+  snprintf(pub->topic_keyexpr, KEYEXPR_MAX_LEN, "%s", clean_topic);
+  z_view_keyexpr_from_str_unchecked(&ke, pub->topic_keyexpr);
 
+  z_publisher_options_t pub_opts;
+  z_publisher_options_default(&pub_opts);
+
+  pub_opts.reliability = Z_RELIABILITY_BEST_EFFORT;
+  pub_opts.congestion_control = Z_CONGESTION_CONTROL_DROP;
+
+  if (
+    z_declare_publisher(
+      z_session_loan(&z_session), &pub->z_pub, z_view_keyexpr_loan(&ke), &pub_opts) != Z_OK)
+  {
+    pub->in_use = false;
+    return NULL;
+  }
+#endif
+
+#if defined(CONFIG_ZENBEDDED_TIER_1)
   pub->attachment.sequence_number = 0;
   pub->attachment.gid_length = RMW_GID_SIZE;
   sys_rand_get(pub->attachment.gid, RMW_GID_SIZE);
@@ -253,15 +307,13 @@ zenbedded_pub_t zenbedded_transport_declare_publisher(
     zid.id[7], zid.id[8], zid.id[9], zid.id[10], zid.id[11], zid.id[12], zid.id[13], zid.id[14],
     zid.id[15], current_node_name, clean_topic, type_name, type_hash);
 
-  LOG_DBG("[WIRE-TRACE] Transmitting Publisher Liveliness Declaration:");
-  LOG_DBG("[WIRE-TRACE] %s", pub->lv_keyexpr);
-
   z_view_keyexpr_t lv_ke;
   z_view_keyexpr_from_str(&lv_ke, pub->lv_keyexpr);
   z_liveliness_declare_token(
     z_session_loan(&z_session), &pub->lv_token, z_view_keyexpr_loan(&lv_ke), NULL);
+#endif
 
-  LOG_INF("Declared Tier 1 Publisher: %s", pub->topic_keyexpr);
+  LOG_INF("Declared Publisher: %s", pub->topic_keyexpr);
   return pub;
 }
 
@@ -272,9 +324,9 @@ int zenbedded_transport_publish(zenbedded_pub_t pub, const uint8_t * payload, si
     return -1;
   }
 
+#if defined(CONFIG_ZENBEDDED_TIER_1)
   struct timespec tv;
   clock_gettime(CLOCK_REALTIME, &tv);
-
   pub->attachment.sequence_number++;
   pub->attachment.timestamp_ns = (int64_t)tv.tv_sec * 1000000000LL + tv.tv_nsec;
 
@@ -288,12 +340,22 @@ int zenbedded_transport_publish(zenbedded_pub_t pub, const uint8_t * payload, si
 
   z_owned_bytes_t z_payload;
   z_bytes_from_static_buf(&z_payload, payload, payload_size);
+  return z_publisher_put(z_publisher_loan(&pub->z_pub), z_bytes_move(&z_payload), &options) == Z_OK
+           ? 0
+           : -1;
 
-  if (z_publisher_put(z_publisher_loan(&pub->z_pub), z_bytes_move(&z_payload), &options) != Z_OK)
-  {
-    return -1;
-  }
-  return 0;
+#elif defined(CONFIG_ZENBEDDED_TIER_2)
+  z_publisher_put_options_t options;
+  z_publisher_put_options_default(&options);
+
+  z_owned_bytes_t z_payload;
+  z_bytes_from_static_buf(&z_payload, payload, payload_size);
+  return z_publisher_put(z_publisher_loan(&pub->z_pub), z_bytes_move(&z_payload), &options) == Z_OK
+           ? 0
+           : -1;
+#endif
+
+  return -1;
 }
 
 zenbedded_sub_t zenbedded_transport_declare_subscriber(
@@ -303,8 +365,6 @@ zenbedded_sub_t zenbedded_transport_declare_subscriber(
   {
     return NULL;
   }
-
-  const char * type_hash = zenbedded_get_rihs_hash(type_name);
 
   struct zenbedded_sub_s * sub = NULL;
   for (int i = 0; i < MAX_SUBSCRIBERS; i++)
@@ -327,9 +387,14 @@ zenbedded_sub_t zenbedded_transport_declare_subscriber(
 
   const char * clean_topic = (topic_name[0] == '/') ? topic_name + 1 : topic_name;
 
+#if defined(CONFIG_ZENBEDDED_TIER_1)
+  const char * type_hash = zenbedded_get_rihs_hash(type_name);
   snprintf(
     sub->topic_keyexpr, KEYEXPR_MAX_LEN, "%u/%s/%s/%s", current_domain_id, clean_topic, type_name,
     type_hash);
+#elif defined(CONFIG_ZENBEDDED_TIER_2)
+  snprintf(sub->topic_keyexpr, KEYEXPR_MAX_LEN, "%s", clean_topic);
+#endif
 
   z_view_keyexpr_t ke;
   z_view_keyexpr_from_str_unchecked(&ke, sub->topic_keyexpr);
@@ -337,6 +402,7 @@ zenbedded_sub_t zenbedded_transport_declare_subscriber(
   z_owned_closure_sample_t sub_cb;
   z_closure_sample(&sub_cb, internal_sub_handler, NULL, sub);
 
+#if defined(CONFIG_ZENBEDDED_TIER_1)
   if (
     z_declare_subscriber(
       z_session_loan(&z_session), &sub->z_sub, z_view_keyexpr_loan(&ke),
@@ -346,7 +412,19 @@ zenbedded_sub_t zenbedded_transport_declare_subscriber(
     LOG_ERR("Failed to declare Zenoh subscriber for %s", sub->topic_keyexpr);
     return NULL;
   }
+#elif defined(CONFIG_ZENBEDDED_TIER_2)
+  if (
+    z_declare_subscriber(
+      z_session_loan(&z_session), &sub->z_sub, z_view_keyexpr_loan(&ke),
+      z_closure_sample_move(&sub_cb), NULL) != Z_OK)
+  {
+    sub->in_use = false;
+    LOG_ERR("Failed to declare Zenoh subscriber for %s", sub->topic_keyexpr);
+    return NULL;
+  }
+#endif
 
+#if defined(CONFIG_ZENBEDDED_TIER_1)
   z_id_t zid = z_info_zid(z_session_loan(&z_session));
   snprintf(
     sub->lv_keyexpr, KEYEXPR_MAX_LEN,
@@ -356,15 +434,12 @@ zenbedded_sub_t zenbedded_transport_declare_subscriber(
     zid.id[7], zid.id[8], zid.id[9], zid.id[10], zid.id[11], zid.id[12], zid.id[13], zid.id[14],
     zid.id[15], current_node_name, clean_topic, type_name, type_hash);
 
-  LOG_DBG("[WIRE-TRACE] Transmitting Subscriber Liveliness Declaration:");
-  LOG_DBG("[WIRE-TRACE] %s", sub->lv_keyexpr);
-
   z_view_keyexpr_t lv_ke;
   z_view_keyexpr_from_str(&lv_ke, sub->lv_keyexpr);
   z_liveliness_declare_token(
     z_session_loan(&z_session), &sub->lv_token, z_view_keyexpr_loan(&lv_ke), NULL);
+#endif
 
-  LOG_INF("Declared Tier 1 Subscriber: %s", sub->topic_keyexpr);
+  LOG_INF("Declared Subscriber: %s", sub->topic_keyexpr);
   return sub;
 }
-#endif  // CONFIG_ZENBEDDED_TIER_1


### PR DESCRIPTION
# Description: 

## 1. Core Transport (zenbedded_transport)
 - Implemented TIER-2 Along with solving the Issue on TIER-1 that is 25 Hz capping for topics. 
 - Eliminated the spin() manual API for zenoh-pico autonomous spin execution (used multithread)
 - Refactored pub and sub declaration and implemented QOS changes for both TIERs
 - Implemented ZENBEDDED_QOS_RELIABILITY(which have tcp/ prepend automatically for the IP:PORT,) and ZENBEDDED_QOS_BEST_EFFORT(which have udp/ prepend automatically)
 - Congestion DROP and Zenoh-best-effort has been hardcoded for the best perfomance.
 - Implemented changing mode(Client or PEER) accordigly {
 ### 4 modes:
  - the defaults are: ZENBEDDED_BEST_EFFORT: udp/, zenoh_best_effort, congestion drop, CLIENT
  - 2nd option is : ZENBEDDED_RELIABLE: tcp/ , zenoh_best effort, congestion drop, CLIENT
  - 3rd one is : ZENBEDDED_BEST_EFFORT: udp/ , zenoh_best_effort, congestion drop, PEER (udp/ multicast, no unicast available)
  - 4th one is: ZENBEDDED_RELIABLE: tcp/ , zenoh_best_effort, congestion drop, PEER (tcp/ unicast)

## 2. Demos & Firmware
 ### zenbedded_test_node (Tier 1):
 - Updated command callback telemetry to utilize a non-blocking 1-second rate limiter to minimize UART bottlenecking during high-frequency testing.

  ### zenbedded_tier2_transport_test (Tier 2): 
 - Implemented an event-driven ping-pong control loop in main.cpp triggered via k_sem_give on packet reception.


Checklist

    [x] Code builds cleanly without warnings under native_sim and esp32s3_devkitc/esp32s3/procpu.

    [x] pre-commit hooks and linters pass (ament_cppcheck, ament_cpplint, clang-format).

    [x] Twister end-to-end integration tests execute with 100% pass rate.

    [x] Upstream changes from origin/master (including PR #62 sample.yaml) preserved without conflict.
    
