### PR TITLE
unify copyright holder

### DIFF
--- a/demos/inverted_pendulum/inverted_pendulum_ros/include/inverted_pendulum_controller/inverted_pendulum_controller.hpp
+++ b/demos/inverted_pendulum/inverted_pendulum_ros/include/inverted_pendulum_controller/inverted_pendulum_controller.hpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/inverted_pendulum/inverted_pendulum_ros/include/mock_pendulum_hardware/mock_pendulum_hardware.hpp
+++ b/demos/inverted_pendulum/inverted_pendulum_ros/include/mock_pendulum_hardware/mock_pendulum_hardware.hpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/inverted_pendulum/inverted_pendulum_ros/launch/inverted_pendulum.launch.py
+++ b/demos/inverted_pendulum/inverted_pendulum_ros/launch/inverted_pendulum.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2026 kamal2730
+# Copyright 2026 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/inverted_pendulum/inverted_pendulum_ros/launch/inverted_pendulum_mock.launch.py
+++ b/demos/inverted_pendulum/inverted_pendulum_ros/launch/inverted_pendulum_mock.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2026 kamal2730
+# Copyright 2026 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/inverted_pendulum/inverted_pendulum_ros/src/inverted_pendulum_controller.cpp
+++ b/demos/inverted_pendulum/inverted_pendulum_ros/src/inverted_pendulum_controller.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/inverted_pendulum/inverted_pendulum_ros/src/mock_pendulum_hardware.cpp
+++ b/demos/inverted_pendulum/inverted_pendulum_ros/src/mock_pendulum_hardware.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/demos/inverted_pendulum/inverted_pendulum_ros/test/test_mock_pendulum_launch.py
+++ b/demos/inverted_pendulum/inverted_pendulum_ros/test/test_mock_pendulum_launch.py
@@ -1,4 +1,4 @@
-# Copyright 2026 kamal2730
+# Copyright 2026 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demos/zenbedded_test_node/src/main.cpp
+++ b/demos/zenbedded_test_node/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 Zenbedded
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 // Licensed under the Apache License, Version 2.0
 
 #include <stdint.h>

--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/interface_schema.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/interface_schema.hpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
+++ b/zenbedded_hardware_interface/include/zenbedded_hardware_interface/zenbedded_hardware.hpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zenbedded_hardware_interface/src/interface_schema.cpp
+++ b/zenbedded_hardware_interface/src/interface_schema.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zenbedded_hardware_interface/src/zenbedded_hardware.cpp
+++ b/zenbedded_hardware_interface/src/zenbedded_hardware.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zenbedded_hardware_interface/test/test_interface_schema.cpp
+++ b/zenbedded_hardware_interface/test/test_interface_schema.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zenbedded_hardware_interface/test/test_zenbedded_hardware.cpp
+++ b/zenbedded_hardware_interface/test/test_zenbedded_hardware.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 kamal2730
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zenbedded_transport/include/zenbedded_transport/serialization.h
+++ b/zenbedded_transport/include/zenbedded_transport/serialization.h
@@ -1,4 +1,4 @@
-// Copyright 2026 Zenbedded
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zenbedded_transport/include/zenbedded_transport/zenoh_transport.h
+++ b/zenbedded_transport/include/zenbedded_transport/zenoh_transport.h
@@ -1,4 +1,4 @@
-// Copyright 2026 Zenbedded
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 // Licensed under the Apache License, Version 2.0
 
 #ifndef ZENBEDDED_TRANSPORT__ZENOH_TRANSPORT_H_

--- a/zenbedded_transport/src/serialization.c
+++ b/zenbedded_transport/src/serialization.c
@@ -1,4 +1,4 @@
-// Copyright 2026 Zenbedded
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zenbedded_transport/src/zenoh_transport.c
+++ b/zenbedded_transport/src/zenoh_transport.c
@@ -1,4 +1,4 @@
-// Copyright 2026 Zenbedded
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 // Licensed under the Apache License, Version 2.0
 
 #include "zenbedded_transport/zenoh_transport.h"

--- a/zenbedded_transport_tests/test/test_cdr_conformance.cpp
+++ b/zenbedded_transport_tests/test/test_cdr_conformance.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 Zenbedded
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Every source file now carries `Open Source Robotics Foundation, Inc.` as the copyright holder. Previously three holders were in circulation ( OSRF (19 files), `kamal2730` (13) and `Zenbedded` (6) ) sometimes within the same module.
- Header lines only; 19 files, one line each, no code touched.

Fixes #10 