### PR TITLE
fix: removed the duplicated entry of schema from the toctree to fix the sphinx build

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,6 @@ Packages
    :titlesonly:
 
    Hardware Interface <../zenbedded_hardware_interface/doc/userdoc.rst>
-   Schema <../zenbedded_transport/doc/userdoc.rst>
    Transport <../zenbedded_transport/doc/userdoc.rst>
    Firmware Client Library <../zenbedded_rcl/doc/userdoc.rst>
 


### PR DESCRIPTION
Deleted the duplicated path of Schema to Transport index for fixing issue #63. 