### PR TITLE
Ensure twister CI carry out tests sequentially

### DIFF
--- a/.github/workflows/zephyr-twister.yml
+++ b/.github/workflows/zephyr-twister.yml
@@ -71,7 +71,8 @@ jobs:
             --platform esp32s3_devkitc/esp32s3/procpu \
             --inline-logs \
             -v \
-            --outdir twister-out
+            --outdir twister-out \
+            --jobs 1
 
       - name: Show twister run output
         if: always()


### PR DESCRIPTION
Some of the twister native sim tests crash because of separate tests clashing. this just ensures everything runs sequentially
