### PR TITLE
Fix ZenbeddedClient teardown and remove unusable RCL config options

### DIFF
--- a/zenbedded_rcl/Kconfig
+++ b/zenbedded_rcl/Kconfig
@@ -23,10 +23,19 @@ menu "Zenbedded RCL Configuration"
     config ZENBEDDED_MAX_STATE_BUFFER_SIZE
         int "Maximum size of state message (for static allocation)"
         default 256
+        range 32 2048
+        help
+            Sizes both state double-buffer slots and a temporary of the same
+            size that zenoh_publish_state() places on the control thread's
+            stack, so raising this eats into ZENBEDDED_RCL_THREAD_STACK_SIZE.
 
     config ZENBEDDED_MAX_CMD_BUFFER_SIZE
         int "Maximum size of cmd message (for static allocation)"
         default 256
+        range 32 2048
+        help
+            Sizes both command double-buffer slots and a temporary of the same
+            size that read_command() places on the calling thread's stack.
 
     config ZENBEDDED_RCL_PUB_TOPIC
         string "Name of the topic for publishing"
@@ -43,26 +52,27 @@ menu "Zenbedded RCL Configuration"
             help
               ROS 2 message type serialized onto ZENBEDDED_RCL_PUB_TOPIC.
 
-            config ZENBEDDED_RCL_STATE_MSG_IMU
-                bool "sensor_msgs/msg/Imu"
-
             config ZENBEDDED_RCL_STATE_MSG_JOINT_STATE
                 bool "sensor_msgs/msg/JointState"
 
-            config ZENBEDDED_RCL_STATE_MSG_FLOAT64_MULTI_ARRAY
-                bool "std_msgs/msg/Float64MultiArray"
-
-            config ZENBEDDED_RCL_STATE_MSG_TWIST
-                bool "geometry_msgs/msg/Twist"
+            # Imu, Float64MultiArray and Twist are disabled until each has a
+            # codec in codecs.hpp and an entry in RIHS_LEDGER. Without both, the
+            # keyexpr ends in UNKNOWN_HASH and no rmw_zenoh peer ever matches.
+            #
+            # config ZENBEDDED_RCL_STATE_MSG_IMU
+            #     bool "sensor_msgs/msg/Imu"
+            #
+            # config ZENBEDDED_RCL_STATE_MSG_FLOAT64_MULTI_ARRAY
+            #     bool "std_msgs/msg/Float64MultiArray"
+            #
+            # config ZENBEDDED_RCL_STATE_MSG_TWIST
+            #     bool "geometry_msgs/msg/Twist"
         endchoice
 
         # Hidden string config for State message
         config ZENBEDDED_RCL_STATE_MSG_TYPE_STRING
             string
-            default "sensor_msgs::msg::dds_::Imu_" if ZENBEDDED_RCL_STATE_MSG_IMU
             default "sensor_msgs::msg::dds_::JointState_" if ZENBEDDED_RCL_STATE_MSG_JOINT_STATE
-            default "std_msgs::msg::dds_::Float64MultiArray_" if ZENBEDDED_RCL_STATE_MSG_FLOAT64_MULTI_ARRAY
-            default "geometry_msgs::msg::dds_::Twist_" if ZENBEDDED_RCL_STATE_MSG_TWIST
 
         choice ZENBEDDED_RCL_CMD_MSG_TYPE
             prompt "Command (subscribed) message type"
@@ -73,19 +83,19 @@ menu "Zenbedded RCL Configuration"
             config ZENBEDDED_RCL_CMD_MSG_JOINT_COMMAND
                 bool "control_msgs/msg/JointCommand"
 
-            config ZENBEDDED_RCL_CMD_MSG_FLOAT64_MULTI_ARRAY
-                bool "std_msgs/msg/Float64MultiArray"
-
-            config ZENBEDDED_RCL_CMD_MSG_TWIST
-                bool "geometry_msgs/msg/Twist"
+            # Disabled for the same reason as the state types above.
+            #
+            # config ZENBEDDED_RCL_CMD_MSG_FLOAT64_MULTI_ARRAY
+            #     bool "std_msgs/msg/Float64MultiArray"
+            #
+            # config ZENBEDDED_RCL_CMD_MSG_TWIST
+            #     bool "geometry_msgs/msg/Twist"
         endchoice
 
         # Hidden string config for Command message
         config ZENBEDDED_RCL_CMD_MSG_TYPE_STRING
             string
             default "control_msgs::msg::dds_::JointCommand_" if ZENBEDDED_RCL_CMD_MSG_JOINT_COMMAND
-            default "std_msgs::msg::dds_::Float64MultiArray_" if ZENBEDDED_RCL_CMD_MSG_FLOAT64_MULTI_ARRAY
-            default "geometry_msgs::msg::dds_::Twist_" if ZENBEDDED_RCL_CMD_MSG_TWIST
 
     endif # ZENBEDDED_TIER_1
 

--- a/zenbedded_rcl/include/zenbedded_rcl/zenbedded_client.hpp
+++ b/zenbedded_rcl/include/zenbedded_rcl/zenbedded_client.hpp
@@ -26,7 +26,7 @@ class ZenbeddedClientBase
 {
 public:
   ZenbeddedClientBase();
-  ~ZenbeddedClientBase() = default;
+  ~ZenbeddedClientBase();
 
   /// @brief Deinitialize the client and underlying transport.
   void destroy();

--- a/zenbedded_rcl/src/zenbedded_client.cpp
+++ b/zenbedded_rcl/src/zenbedded_client.cpp
@@ -18,7 +18,14 @@
 
 LOG_MODULE_REGISTER(zenbedded_client, LOG_LEVEL_INF);
 
+BUILD_ASSERT(
+  2 * CONFIG_ZENBEDDED_MAX_STATE_BUFFER_SIZE < CONFIG_ZENBEDDED_RCL_THREAD_STACK_SIZE,
+  "CONFIG_ZENBEDDED_MAX_STATE_BUFFER_SIZE leaves too little control thread stack; "
+  "raise CONFIG_ZENBEDDED_RCL_THREAD_STACK_SIZE");
+
 ZenbeddedClientBase::ZenbeddedClientBase() { reset_buffers(); }
+
+ZenbeddedClientBase::~ZenbeddedClientBase() { destroy(); }
 
 int ZenbeddedClientBase::init_base(
   uint32_t control_freq, size_t state_payload_size, size_t cmd_payload_size)
@@ -95,6 +102,8 @@ void ZenbeddedClientBase::destroy()
   stop_thread();
   zenbedded_transport_destroy();
 
+  pub_ = nullptr;
+  sub_ = nullptr;
   initialized_ = false;
   LOG_INF("ZenbeddedClient deinitialized");
 }
@@ -197,14 +206,7 @@ void ZenbeddedClientBase::stop_thread()
   LOG_INF("Stopping control thread");
   atomic_set(&control_thread_running_, 0);  // cleanly exit thread loop
 
-  int timeout_ms = 200;
-  while (atomic_get(&control_thread_running_) != 0 && timeout_ms > 0)
-  {
-    k_sleep(K_MSEC(10));
-    timeout_ms -= 10;
-  }
-
-  if (timeout_ms <= 0)
+  if (k_thread_join(&control_thread_, K_MSEC(200)) != 0)
   {
     LOG_WRN("Control thread did not stop gracefully");
     k_thread_abort(&control_thread_);


### PR DESCRIPTION
- Destroying a client, or calling `destroy()`, now actually stops the publish thread. `stop_thread()` was waiting on the flag it had just cleared, so it returned immediately and the transport was torn down under a live publish; the defaulted destructor never stopped the thread at all, leaving it running against a dangling object and its embedded kernel stack. It now joins the thread, and `destroy()` clears the pub/sub handles.
- `ZENBEDDED_MAX_STATE_BUFFER_SIZE` / `_CMD_BUFFER_SIZE` are bounded, and a build assert rejects a state buffer too large for the control thread's stack. Both sizes feed stack temporaries, so raising them used to silently overflow that stack.
- The Tier-1 message types with no codec and no `RIHS_LEDGER` entry (Imu, Float64MultiArray, Twist) are no longer selectable. Picking one built and ran fine but produced an `UNKNOWN_HASH` keyexpr that no rmw_zenoh peer ever matched.